### PR TITLE
Swapped "Blog" anchor in navigation for "University" anchor, linking to Domo U with grad-cap icon in place of newspaper.

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -31,9 +31,9 @@
           "icon": "people-group"
         },
         {
-          "anchor": "Blog",
-          "href": "https://www.domo.com/blog/category/domo-community",
-          "icon": "newspaper"
+          "anchor": "University",
+          "href": "https://www.domo.com/domo-central/university",
+          "icon": "graduation-cap"
         }
       ]
     },


### PR DESCRIPTION
Swapped "Blog" anchor for "University" anchor, with new link to Domo U and grad-cap icon in place of newspaper icon.