### PR TITLE
Fix DomoJS Docs

### DIFF
--- a/portal/Apps/App-Framework/Guides/handling-data-updates.mdx
+++ b/portal/Apps/App-Framework/Guides/handling-data-updates.mdx
@@ -57,7 +57,7 @@ Replace the `index.html` content with the following:
     <div id="updateCount">0</div>
 
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/portal/Apps/App-Framework/Tools/domo-js-v4.mdx
+++ b/portal/Apps/App-Framework/Tools/domo-js-v4.mdx
@@ -74,14 +74,16 @@ const domo = require('ryuu.js');
 
 ### CDN / Script Tag
 
-The CLI scaffolds this automatically via `domo init`. The bundle exposes a global `domo` object:
+Load the library directly from a CDN. The bundle exposes a global `domo` object:
 
 ```html
-<script src="domo.js"></script>
+<script src="https://unpkg.com/ryuu.js"></script>
 <script>
   domo.get('/data/v1/sales').then(data => console.log(data));
 </script>
 ```
+
+When using the Domo CLI, `domo init` scaffolds a local `domo.js` file you can reference with `<script src="domo.js"></script>` instead.
 
 ### TypeScript
 

--- a/portal/Apps/App-Framework/Tools/domo-js.mdx
+++ b/portal/Apps/App-Framework/Tools/domo-js.mdx
@@ -99,14 +99,16 @@ const domo = require('ryuu.js').default;
 
 ### CDN / Script Tag
 
-The CLI scaffolds this automatically via `domo init`. The bundle exposes a global `Domo` object:
+Load the library directly from a CDN. The bundle exposes a global `domo` object:
 
 ```html
-<script src="domo.js"></script>
+<script src="https://unpkg.com/ryuu.js"></script>
 <script>
   domo.data.query('sales').then(rows => console.log(rows));
 </script>
 ```
+
+When using the Domo CLI, `domo init` scaffolds a local `domo.js` file you can reference with `<script src="domo.js"></script>` instead.
 
 ### TypeScript
 

--- a/portal/Apps/App-Framework/Tutorials/javascript/DynamicInfographic.mdx
+++ b/portal/Apps/App-Framework/Tutorials/javascript/DynamicInfographic.mdx
@@ -193,7 +193,7 @@ The `index.html` file contains the basic structure of our page and loads our Jav
   <body>
     <h1>canva infographic walkthrough</h1>
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
   </body>
 </html>
@@ -262,7 +262,7 @@ Note: we are loading in fonts from Google Fonts to match the look and feel of th
     <span id="market-type" class="description">36 (Seller's Market)</span>
 
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
   </body>
 </html>
@@ -401,7 +401,7 @@ After defining our structure, we need to set these variables into our HTML code 
     <span id="market-type" class="description">{market_type}</span>
 
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/portal/Apps/App-Framework/Tutorials/javascript/HelloWorld.mdx
+++ b/portal/Apps/App-Framework/Tutorials/javascript/HelloWorld.mdx
@@ -350,7 +350,7 @@ Our final `index.html` file should look like the following:
     <div class="accordion" id="accordion"></div>
 
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/portal/Apps/App-Framework/Tutorials/javascript/ReturnFlow.mdx
+++ b/portal/Apps/App-Framework/Tutorials/javascript/ReturnFlow.mdx
@@ -141,7 +141,7 @@ The `index.html` file contains the basic structure of our page and loads our Jav
   <body>
     <h1>Return Flow</h1>
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/portal/Apps/App-Framework/Tutorials/javascript/game-night-planner-app/going-from-brick-to-app.mdx
+++ b/portal/Apps/App-Framework/Tutorials/javascript/game-night-planner-app/going-from-brick-to-app.mdx
@@ -61,7 +61,7 @@ Let's explore these files briefly.
   <body>
     <h1>GameNightPlannerNF</h1>
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
   </body>
 </html>
@@ -219,7 +219,7 @@ Update your `index.html` file with a new title.
   <body>
     <h1>Game Night Planner</h1>
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="app.js"></script>
   </body>
 </html>
@@ -253,7 +253,7 @@ Our HTML code, can be copied in our `index.html` file. Your updated `index.html`
     <div id="tabulator-table"></div>
 
     {/* domo.js optional utils */}
-    <script src="domo.js"></script>
+    <script src="https://unpkg.com/ryuu.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/tabulator-tables@6.0.1/dist/js/tabulator.min.js"></script>
     <script src="app.js"></script>
   </body>


### PR DESCRIPTION
## Summary

- Replaces `<script src="domo.js"></script>` with `<script src="https://unpkg.com/ryuu.js"></script>` in all active tutorials, guides, and reference docs so copy-paste examples work standalone without requiring `domo init`-scaffolded files on disk.
- Aligns with the existing CDN pattern already used in `Apps/Pro-Code-Editor/Tutorials/stacked-bars.mdx` and `pdf-export.mdx`.
- Updates the surrounding prose in `Tools/domo-js.mdx` and `Tools/domo-js-v4.mdx` so the "CDN / Script Tag" sections describe the CDN correctly, with a follow-up note that `domo init` still scaffolds a local `domo.js` alternative.

**Files modified (7):**
- `portal/Apps/App-Framework/Tools/domo-js.mdx`
- `portal/Apps/App-Framework/Tools/domo-js-v4.mdx`
- `portal/Apps/App-Framework/Tutorials/javascript/HelloWorld.mdx`
- `portal/Apps/App-Framework/Tutorials/javascript/ReturnFlow.mdx`
- `portal/Apps/App-Framework/Tutorials/javascript/DynamicInfographic.mdx`
- `portal/Apps/App-Framework/Tutorials/javascript/game-night-planner-app/going-from-brick-to-app.mdx`
- `portal/Apps/App-Framework/Guides/handling-data-updates.mdx`

**Intentionally skipped:** Files under `portal/_archived/2026-01-27/` — not in `docs.json` navigation, not served.

## Test plan

- [ ] Verify Mintlify preview renders the updated code blocks without MDX errors
- [ ] Spot-check that each example HTML block is still copy-paste runnable (unpkg loads, `app.js` still relative, global `domo` object present)
- [ ] Confirm the reference-doc prose reads correctly in `domo-js.mdx` and `domo-js-v4.mdx` CDN sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)