### PR TITLE
Included Expand Admin Details field and other missing fields

### DIFF
--- a/s/article/360043434973.mdx
+++ b/s/article/360043434973.mdx
@@ -1281,6 +1281,30 @@ This pane contains a primary **Reports** menu, along with various other menus wh
     
 </tr>
 
+
+<tr>
+
+      
+<td colspan="1" rowspan="1">
+
+        {" "}
+        Fields{" "}
+      
+</td>
+
+      
+<td colspan="1" rowspan="1">
+
+        
+<span>
+ Enter comma-separated parent field IDs to filter. Child fields are included automatically. You can exclude only parent fields. For custom fields, enter the field IDs. Use the Fields report to view supported fields. 
+</span>
+
+      
+</td>
+
+    
+</tr>
     
 <tr>
 
@@ -1392,6 +1416,174 @@ This pane contains a primary **Reports** menu, along with various other menus wh
 
           {" "}
           Enter the group that contains the users you wish to retrieve. This report requires an Administrator account.{" "}
+        
+</span>
+
+      
+</td>
+
+    
+</tr>
+
+
+<tr>
+
+      
+<td colspan="1" rowspan="1">
+
+        {" "}
+        Agile Boards{" "}
+      
+</td>
+
+      
+<td colspan="1" rowspan="1">
+
+        
+<span>
+
+          {" "}
+          Choose the Agile board to retrieve data.{" "}
+        
+</span>
+
+      
+</td>
+
+    
+</tr>
+
+
+<tr>
+
+      
+<td colspan="1" rowspan="1">
+
+        {" "}
+        Sprint Selection{" "}
+      
+</td>
+
+      
+<td colspan="1" rowspan="1">
+
+        
+<span>
+
+          {" "}
+          Show issues from the active sprint, future sprints, or a selected sprint.{" "}
+        
+</span>
+
+      
+</td>
+
+    
+</tr>
+
+
+<tr>
+
+      
+<td colspan="1" rowspan="1">
+
+        {" "}
+        Agile Sprints{" "}
+      
+</td>
+
+      
+<td colspan="1" rowspan="1">
+
+        
+<span>
+
+          {" "}
+          Select the sprint to retrieve data from.{" "}
+        
+</span>
+
+      
+</td>
+
+    
+</tr>
+
+
+<tr>
+
+      
+<td colspan="1" rowspan="1">
+
+        {" "}
+        Sprint Start Date After{" "}
+      
+</td>
+
+      
+<td colspan="1" rowspan="1">
+
+        
+<span>
+
+          {" "}
+          If a sprint starts after the selected start date, all issues that fall within those sprints will be retrieved.{" "}
+        
+</span>
+
+      
+</td>
+
+    
+</tr>
+
+
+<tr>
+
+      
+<td colspan="1" rowspan="1">
+
+        {" "}
+        Project{" "}
+      
+</td>
+
+      
+<td colspan="1" rowspan="1">
+
+        
+<span>
+
+          {" "}
+          Select the JIRA project to retrieve data from.{" "}
+        
+</span>
+
+      
+</td>
+
+    
+</tr>
+
+
+<tr>
+
+      
+<td colspan="1" rowspan="1">
+
+        {" "}
+        Expand Admin Details{" "}
+      
+</td>
+
+      
+<td colspan="1" rowspan="1">
+
+        
+<span>
+
+          {" "}
+          Enable this option to include detailed admin user information for each board. Each admin appears in a separate row. This option is disabled by default.{" "}
         
 </span>
 


### PR DESCRIPTION
Included the following fields in the details section:

- Fields
- Agile Boards
- Sprint Selection
- Agile Sprints
- Sprint Start Date After
- Project
- Expand Admin Details