### PR TITLE
Add troubleshooting steps for mintlify "Client not built" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,34 @@ Open <http://localhost:3000>. Most edits hot-reload; `docs.json` schema changes 
 
 For a faster, but less robust preview experience, VS Code has several extenstions offering an MDX preview. For example: [Modern MDX Preview](https://marketplace.visualstudio.com/items?itemName=ggfincke.vsc-mdx-preview).
 
+### Troubleshooting
+
+#### "Client not built" error
+
+If `mintlify dev` fails with:
+
+```text
+Error: Client not built. Run: cd <path>/apps/client && STANDALONE_BUILD=true NEXT_PUBLIC_ENV=cli yarn build
+```
+
+The Mintlify CLI's internal `tar` library may have silently skipped dotfile directories (like `.next/`) when extracting its client package, leaving the cache broken (see [this issue](https://github.com/mintlify/docs/issues/5624)). Work around it by extracting manually with the system `tar`:
+
+```bash
+# 1. Clear the broken cache
+rm -rf ~/.mintlify
+
+# 2. Download the client package manually (uses system tar, which handles dotfiles correctly)
+VERSION=$(curl -s https://releases.mintlify.com/mint-version.txt)
+mkdir -p ~/.mintlify
+curl -s -o /tmp/mint.tar.gz "https://releases.mintlify.com/mint-${VERSION}.tar.gz"
+tar -xzf /tmp/mint.tar.gz -C ~/.mintlify
+echo "$VERSION" > ~/.mintlify/mint/mint-version.txt
+rm /tmp/mint.tar.gz
+
+# 3. Run as normal — mintlify will see the version file and skip the re-download
+mintlify dev
+```
+
 ## Deployment
 
 - **`main`** — merges auto-deploy to production via the Mintlify GitHub App.


### PR DESCRIPTION
## Summary

- Adds a troubleshooting section to the README for the `mintlify dev` "Client not built" error
- Root cause: we think the npm `tar@6.1.15` package used internally by `@mintlify/previewing` silently skips `.next/` (a dotfile directory) when extracting the downloaded client tarball on macOS arm64.
    - I opened [an issue with mintlify about it](https://github.com/mintlify/docs/issues/5624)
- The workaround is to clear `~/.mintlify` and re-extract using the system `tar` binary, which handles dotfile directories correctly

Bug filed upstream: https://github.com/mintlify/docs/issues/5624

## Test plan

- [x] Verify the README renders correctly on the repo's GitHub page
- [x] Confirm the bash commands in the workaround are accurate (validated during local debugging session and manually by Brad)
