### PR TITLE
Fix typo

### DIFF
--- a/portal/Connectors/Custom-Connectors/connector-dev-studio.mdx
+++ b/portal/Connectors/Custom-Connectors/connector-dev-studio.mdx
@@ -39,7 +39,7 @@ To build a custom connector, the API you wish to connect to must meet a few requ
 
 <Note>
 **Note**
-Because the IDE is built using the [Java 17 Graavl engine], you need to write your code using JavaScript compatible with [ECMAScript 5 (ES5)](https://www.w3schools.com/js/js_es5.asp). For example, Xmlhttprequest is not supported. Use httprequest in its place:
+Because the IDE is built using the [Java 17 GraalVM engine], you need to write your code using JavaScript compatible with [ECMAScript 5 (ES5)](https://www.w3schools.com/js/js_es5.asp). For example, Xmlhttprequest is not supported. Use httprequest in its place:
 </Note>
 
 ```javascript


### PR DESCRIPTION
I looked it up to be sure that "Graavl engine" is _not_ a thing and that "GraalVM" is a thing.

https://www.google.com/search?q=Java+17+Graavl+engine