### PR TITLE
docs: expand pfilter operands reference with full operator list and examples

### DIFF
--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -103,17 +103,6 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
   **URL-encode special characters in `LIKE` and `NOT_LIKE` patterns.** Because pfilters are passed as URL query parameters, the `%` wildcard must be encoded as `%25` — a raw `%` will be misinterpreted as the start of a percent-encoded character and the filter will not work.
 </Warning>
 
-<Note>
-  **LIKE and NOT_LIKE pattern matching details**
-
-  | Feature | Behavior |
-  |---|---|
-  | `%` wildcard | Matches **zero or more** characters. `Apple%` matches "Apple" exactly (zero trailing characters); `%an%` matches any value containing "an"; `%` alone matches every row. |
-  | `_` wildcard | Matches **exactly one** character. `US-__` matches "US-CA" but not "US-C" (too short) or "US-CAL" (too long). Use one `_` per required character. |
-  | Case sensitivity | Matching is **case-insensitive**. `B%` and `b%` return the same results. |
-  | Bracket notation | `[charlist]` syntax (e.g. `[AB]%`) is **not supported**. The brackets are treated as literal characters — `[AB]%` only matches values that literally start with `[AB]`, not values starting with A or B. |
-</Note>
-
 <Tip>
   **Special characters in the `pfilters` value can be mangled by text tools.** Characters like `[`, `]`, `{`, `}`, `"`, `%`, and `+` appear throughout every pfilter and are meaningful in URLs. Email clients, Markdown renderers, CMS fields, Slack, and spreadsheet tools can silently strip, escape, or re-encode them — producing a URL that looks correct but fails at runtime.
 

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -84,17 +84,17 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 
 | Operand | Description | Example |
 |---|---|---|
-| `IN` | Matches any of the provided values (exact match); also works with numeric columns | `?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending","Closed"]}]` |
-| `NOT_IN` | Excludes all of the provided values; also works with numeric columns | `?pfilters=[{"column":"Status","operand":"NOT_IN","values":["Deleted","Archived"]}]` |
+| `IN` | Matches any of the provided values (**case-sensitive**); also works with numeric columns | `?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending","Closed"]}]` |
+| `NOT_IN` | Excludes all of the provided values (**case-sensitive**); also works with numeric columns | `?pfilters=[{"column":"Status","operand":"NOT_IN","values":["Deleted","Archived"]}]` |
 | `IN_IGNORE_CASE` | Same as `IN` but case-insensitive | `?pfilters=[{"column":"Region","operand":"IN_IGNORE_CASE","values":["north america"]}]` — also matches "North America" and "NORTH AMERICA" |
-| `CONTAINS` | Matches rows where the column contains the substring | `?pfilters=[{"column":"Title","operand":"CONTAINS","values":["Q4"]}]` — matches "Q4 Report", "TORQ4MOTORS" |
-| `NOT_CONTAINS` | Matches rows where the column does not contain the substring | `?pfilters=[{"column":"Title","operand":"NOT_CONTAINS","values":["draft"]}]` |
-| `STARTS_WITH` | Matches rows where the column value begins with the string | `?pfilters=[{"column":"Message","operand":"STARTS_WITH","values":["Error"]}]` — matches "Error 404", "Error: timeout" |
-| `NOT_STARTS_WITH` | Matches rows where the column value does not begin with the string | `?pfilters=[{"column":"Name","operand":"NOT_STARTS_WITH","values":["test_"]}]` |
-| `ENDS_WITH` | Matches rows where the column value ends with the string | `?pfilters=[{"column":"Market","operand":"ENDS_WITH","values":["_US"]}]` |
-| `NOT_ENDS_WITH` | Matches rows where the column value does not end with the string | `?pfilters=[{"column":"Config","operand":"NOT_ENDS_WITH","values":["_old"]}]` |
-| `EQUALS` | Exact match (also works for numeric columns) | `?pfilters=[{"column":"Region","operand":"EQUALS","values":["North America"]}]` — "north america" would not match |
-| `NOT_EQUALS` | Excludes exact match (also works for numeric columns) | `?pfilters=[{"column":"Status","operand":"NOT_EQUALS","values":["N/A"]}]` |
+| `CONTAINS` | Matches rows where the column contains the substring (**case-insensitive**) | `?pfilters=[{"column":"Title","operand":"CONTAINS","values":["Q4"]}]` — matches "Q4 Report", "TORQ4MOTORS", and "q4 summary" |
+| `NOT_CONTAINS` | Matches rows where the column does not contain the substring (**case-insensitive**) | `?pfilters=[{"column":"Title","operand":"NOT_CONTAINS","values":["draft"]}]` — also excludes "Draft" and "DRAFT" |
+| `STARTS_WITH` | Matches rows where the column value begins with the string (**case-insensitive**) | `?pfilters=[{"column":"Message","operand":"STARTS_WITH","values":["error"]}]` — matches "Error 404", "ERROR: timeout", and "error occurred" |
+| `NOT_STARTS_WITH` | Matches rows where the column value does not begin with the string (**case-insensitive**) | `?pfilters=[{"column":"Name","operand":"NOT_STARTS_WITH","values":["test_"]}]` — also excludes "TEST_user" |
+| `ENDS_WITH` | Matches rows where the column value ends with the string (**case-insensitive**) | `?pfilters=[{"column":"Market","operand":"ENDS_WITH","values":["_us"]}]` — matches "_US", "_Us", and "_us" |
+| `NOT_ENDS_WITH` | Matches rows where the column value does not end with the string (**case-insensitive**) | `?pfilters=[{"column":"Config","operand":"NOT_ENDS_WITH","values":["_old"]}]` — also excludes values ending in "_OLD" or "_Old" |
+| `EQUALS` | **Case-sensitive** exact match (also works for numeric columns) | `?pfilters=[{"column":"Region","operand":"EQUALS","values":["North America"]}]` — "north america" and "NORTH AMERICA" do not match |
+| `NOT_EQUALS` | Excludes **case-sensitive** exact match (also works for numeric columns) | `?pfilters=[{"column":"Status","operand":"NOT_EQUALS","values":["N/A"]}]` — "n/a" and "N/a" are not excluded |
 | `EQUALS_IGNORE_CASE` | Case-insensitive exact match | `?pfilters=[{"column":"Status","operand":"EQUALS_IGNORE_CASE","values":["active"]}]` — matches "active", "Active", and "ACTIVE" |
 | `LIKE` | SQL-style pattern match (`%` = zero or more characters, `_` = exactly one character); **matching is case-insensitive** | `?pfilters=[{"column":"Region","operand":"LIKE","values":["US-__"]}]` — matches "US-CA" and "US-TX" but not "US-C" (too short) or "US-CAL" (too long) |
 | `NOT_LIKE` | Excludes rows matching the SQL-style pattern (same wildcards and case-insensitive behavior as `LIKE`) | `?pfilters=[{"column":"Title","operand":"NOT_LIKE","values":["%25archived%25"]}]` — excludes any value containing "archived" |

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -80,55 +80,37 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 
 #### String operands
 
-| Operand | Values | Description |
+| Operand | Description | Example |
 |---|---|---|
-| `IN` | Array of strings | Matches any of the provided values (exact match) |
-| `NOT_IN` | Array of strings | Excludes all of the provided values |
-| `IN_IGNORE_CASE` | Array of strings | Same as `IN` but case-insensitive |
-| `CONTAINS` | Single string | Matches rows where the column contains the substring |
-| `NOT_CONTAINS` | Single string | Matches rows where the column does not contain the substring |
-| `STARTS_WITH` | Single string | Matches rows where the column value begins with the string |
-| `NOT_STARTS_WITH` | Single string | Matches rows where the column value does not begin with the string |
-| `ENDS_WITH` | Single string | Matches rows where the column value ends with the string |
-| `NOT_ENDS_WITH` | Single string | Matches rows where the column value does not end with the string |
-| `EQUALS` | Single string | Exact match (also works for numeric columns) |
-| `NOT_EQUALS` | Single string | Excludes exact match (also works for numeric columns) |
-| `EQUALS_IGNORE_CASE` | Single string | Case-insensitive exact match |
-| `LIKE` | Single string | SQL-style pattern match — use `%` as a wildcard (e.g. `%revenue%`) |
-| `NOT_LIKE` | Single string | Excludes rows matching the SQL-style pattern |
+| `IN` | Matches any of the provided values (exact match) | `?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending","Closed"]}]` |
+| `NOT_IN` | Excludes all of the provided values | `?pfilters=[{"column":"Status","operand":"NOT_IN","values":["Deleted","Archived"]}]` |
+| `IN_IGNORE_CASE` | Same as `IN` but case-insensitive | `?pfilters=[{"column":"Region","operand":"IN_IGNORE_CASE","values":["north america"]}]` — also matches "North America" and "NORTH AMERICA" |
+| `CONTAINS` | Matches rows where the column contains the substring | `?pfilters=[{"column":"Title","operand":"CONTAINS","values":["Q4"]}]` — matches "Q4 Report", "TORQ4MOTORS" |
+| `NOT_CONTAINS` | Matches rows where the column does not contain the substring | `?pfilters=[{"column":"Title","operand":"NOT_CONTAINS","values":["draft"]}]` |
+| `STARTS_WITH` | Matches rows where the column value begins with the string | `?pfilters=[{"column":"Message","operand":"STARTS_WITH","values":["Error"]}]` — matches "Error 404", "Error: timeout" |
+| `NOT_STARTS_WITH` | Matches rows where the column value does not begin with the string | `?pfilters=[{"column":"Name","operand":"NOT_STARTS_WITH","values":["test_"]}]` |
+| `ENDS_WITH` | Matches rows where the column value ends with the string | `?pfilters=[{"column":"Market","operand":"ENDS_WITH","values":["_US"]}]` |
+| `NOT_ENDS_WITH` | Matches rows where the column value does not end with the string | `?pfilters=[{"column":"Config","operand":"NOT_ENDS_WITH","values":["_old"]}]` |
+| `EQUALS` | Exact match (also works for numeric columns) | `?pfilters=[{"column":"Region","operand":"EQUALS","values":["North America"]}]` — "north america" would not match |
+| `NOT_EQUALS` | Excludes exact match (also works for numeric columns) | `?pfilters=[{"column":"Status","operand":"NOT_EQUALS","values":["N/A"]}]` |
+| `EQUALS_IGNORE_CASE` | Case-insensitive exact match | `?pfilters=[{"column":"Status","operand":"EQUALS_IGNORE_CASE","values":["active"]}]` — matches "active", "Active", and "ACTIVE" |
+| `LIKE` | SQL-style pattern match (`%` = any characters, `_` = exactly one character) | `?pfilters=[{"column":"Region","operand":"LIKE","values":["US-__"]}]` — matches "US-CA", "US-TX" but not "US-CAL" |
+| `NOT_LIKE` | Excludes rows matching the SQL-style pattern | `?pfilters=[{"column":"Title","operand":"NOT_LIKE","values":["%archived%"]}]` — excludes any value containing "archived" |
 
 #### Numeric operands
 
-| Operand | Values | Description |
+| Operand | Description | Example |
 |---|---|---|
-| `GREATER_THAN` | Single number | Matches rows where the column value is greater than the provided number |
-| `GREAT_THAN_EQUALS_TO` | Single number | Matches rows where the column value is greater than or equal to the provided number |
-| `LESS_THAN` | Single number | Matches rows where the column value is less than the provided number |
-| `LESS_THAN_EQUALS_TO` | Single number | Matches rows where the column value is less than or equal to the provided number |
-| `BETWEEN` | Two numbers `[min, max]` | Matches rows where the column value falls within the range (inclusive) |
-| `NOT_BETWEEN` | Two numbers `[min, max]` | Matches rows where the column value falls outside the range |
+| `GREATER_THAN` | Matches rows where the column value is greater than the provided number | `?pfilters=[{"column":"Revenue","operand":"GREATER_THAN","values":[100]}]` |
+| `GREAT_THAN_EQUALS_TO` | Matches rows where the column value is greater than or equal to the provided number | `?pfilters=[{"column":"Score","operand":"GREAT_THAN_EQUALS_TO","values":[0]}]` — matches zero and all positive values |
+| `LESS_THAN` | Matches rows where the column value is less than the provided number | `?pfilters=[{"column":"Revenue","operand":"LESS_THAN","values":[1000]}]` |
+| `LESS_THAN_EQUALS_TO` | Matches rows where the column value is less than or equal to the provided number | `?pfilters=[{"column":"Score","operand":"LESS_THAN_EQUALS_TO","values":[100]}]` |
+| `BETWEEN` | Matches rows where the column value falls within the range (inclusive) — requires two values | `?pfilters=[{"column":"Revenue","operand":"BETWEEN","values":[1000,5000]}]` — matches 1000, 2500, and 5000 but not 999 or 5001 |
+| `NOT_BETWEEN` | Matches rows where the column value falls outside the range — requires two values | `?pfilters=[{"column":"Score","operand":"NOT_BETWEEN","values":[0,10]}]` — matches anything below 0 or above 10 |
 
-### Operand examples
+### Combining multiple operands
 
-**CONTAINS** — filter to rows where a column contains a substring:
-
-```url
-?pfilters=[{"column":"testName","operand":"CONTAINS","values":["OAuth"]}]
-```
-
-**BETWEEN** — filter to a numeric range (note: two values in the array):
-
-```url
-?pfilters=[{"column":"Revenue","operand":"BETWEEN","values":[1000,5000]}]
-```
-
-**LIKE** — SQL-style wildcard match (`%` matches any sequence of characters):
-
-```url
-?pfilters=[{"column":"Description","operand":"LIKE","values":["%revenue%"]}]
-```
-
-**Multiple filters** — combine operands in the same `pfilters` array:
+To apply more than one filter at once, add multiple objects to the `pfilters` array:
 
 ```url
 ?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending"]},{"column":"Score","operand":"GREATER_THAN","values":[50]}]

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -119,13 +119,12 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 
   **Online:** paste your pfilter value into [URLEncoder.org](https://www.urlencoder.org/) and copy the encoded result.
 
-  **Locally:** run the following command, paste your full URL at the prompt, and press Enter:
+  **Locally:** adapt and run the following command in a browser console:
 
   ```bash
-  node -e "const rl=require('readline').createInterface({input:process.stdin,output:process.stdout});rl.question('Paste full URL: ',v=>{console.log(encodeURI(v));rl.close()})"
+  copy( encodeURI(`https://embed.domo.com/cards/ABCD?pfilters=[{"column": "Customer Segment", "operand": "IN", "values": ["Home Office"]}, {"column":"Description", "operand":"NOT_LIKE", "values":["%test%"]}]`) )
+  # https://embed.domo.com/cards/ABCD?pfilters=%5B%7B%22column%22:%20%22Customer%20Segment%22,%20%22operand%22:%20%22IN%22,%20%22values%22:%20%5B%22Home%20Office%22%5D%7D,%20%7B%22column%22:%22Description%22,%20%22operand%22:%22NOT_LIKE%22,%20%22values%22:%5B%22%25test%25%22%5D%7D%5D
   ```
-
-  Use the encoded URL as-is.
 </Tip>
 
 #### Numeric operands

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -142,19 +142,19 @@ To apply more than one filter at once, add multiple objects to the `pfilters` ar
 Domo automatically creates Pfilters when you check Persist Filters in the embed dialog, as shown here:
 
 <Frame>
-  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.02.05-PM.png>)
+  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.02.05-PM.png)
 </Frame>
 
 You can then view the parameters by hovering over the content. (Card interactions must be turned on and set to External link for this to work). This is shown for the "QA pass rate by model" Card in the following example:
 
 <Frame>
-  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.03.02-PM.png>)
+  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.03.02-PM.png)
 </Frame>
 
 When viewers click those links, any parts of the story they had previously clicked will be passed along as Pfilters to the next Page. These filters can either be applied to single Cards or complete Pages (even if the Pages contain many Cards based on various DataSets).
 
 <Frame>
-  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.04.56-PM.png>)
+  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.04.56-PM.png)
 </Frame>
 
 ### Persistence of Pfilters across sessions
@@ -166,7 +166,7 @@ If you want Pfilters to expand beyond pages to also persist across sessions and 
 If a Pfilter is written incorrectly, the unfiltered version renders and a black error bar appears.
 
 <Frame>
-  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.06.54-PM.png>)
+  ![](/images/dev/stoplight.io/images/Screenshot-2023-11-09-at-12.06.54-PM.png)
 </Frame>
 
 ## AppData

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -76,17 +76,63 @@ example.domo.com/embed/pages/private/ABCDE
 
 ### Operands
 
-The operands you can use when writing code with Pfilters are as follows. Note that the values always need square brackets for the array, even when only a single value is included.
+The operands you can use when writing Pfilters are listed below. The `values` field is always an array (square brackets), even when only a single value is provided.
 
-- IN
-- CONTAINS
-- EQUALS
-- NOT_EQUALS
-- GREATER_THAN
-- LESS_THAN
-- GREAT_THAN_EQUALS_TO
-- LESS_THAN_EQUALS_TO
-- BETWEEN
+#### String operands
+
+| Operand | Values | Description |
+|---|---|---|
+| `IN` | Array of strings | Matches any of the provided values (exact match) |
+| `NOT_IN` | Array of strings | Excludes all of the provided values |
+| `IN_IGNORE_CASE` | Array of strings | Same as `IN` but case-insensitive |
+| `CONTAINS` | Single string | Matches rows where the column contains the substring |
+| `NOT_CONTAINS` | Single string | Matches rows where the column does not contain the substring |
+| `STARTS_WITH` | Single string | Matches rows where the column value begins with the string |
+| `NOT_STARTS_WITH` | Single string | Matches rows where the column value does not begin with the string |
+| `ENDS_WITH` | Single string | Matches rows where the column value ends with the string |
+| `NOT_ENDS_WITH` | Single string | Matches rows where the column value does not end with the string |
+| `EQUALS` | Single string | Exact match (also works for numeric columns) |
+| `NOT_EQUALS` | Single string | Excludes exact match (also works for numeric columns) |
+| `EQUALS_IGNORE_CASE` | Single string | Case-insensitive exact match |
+| `LIKE` | Single string | SQL-style pattern match — use `%` as a wildcard (e.g. `%revenue%`) |
+| `NOT_LIKE` | Single string | Excludes rows matching the SQL-style pattern |
+
+#### Numeric operands
+
+| Operand | Values | Description |
+|---|---|---|
+| `GREATER_THAN` | Single number | Matches rows where the column value is greater than the provided number |
+| `GREAT_THAN_EQUALS_TO` | Single number | Matches rows where the column value is greater than or equal to the provided number |
+| `LESS_THAN` | Single number | Matches rows where the column value is less than the provided number |
+| `LESS_THAN_EQUALS_TO` | Single number | Matches rows where the column value is less than or equal to the provided number |
+| `BETWEEN` | Two numbers `[min, max]` | Matches rows where the column value falls within the range (inclusive) |
+| `NOT_BETWEEN` | Two numbers `[min, max]` | Matches rows where the column value falls outside the range |
+
+### Operand examples
+
+**CONTAINS** — filter to rows where a column contains a substring:
+
+```url
+?pfilters=[{"column":"testName","operand":"CONTAINS","values":["OAuth"]}]
+```
+
+**BETWEEN** — filter to a numeric range (note: two values in the array):
+
+```url
+?pfilters=[{"column":"Revenue","operand":"BETWEEN","values":[1000,5000]}]
+```
+
+**LIKE** — SQL-style wildcard match (`%` matches any sequence of characters):
+
+```url
+?pfilters=[{"column":"Description","operand":"LIKE","values":["%revenue%"]}]
+```
+
+**Multiple filters** — combine operands in the same `pfilters` array:
+
+```url
+?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending"]},{"column":"Score","operand":"GREATER_THAN","values":[50]}]
+```
 
 ### Persistence of Pfilters across Pages
 

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -104,7 +104,7 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 </Warning>
 
 <Tip>
-  **Special characters in the `pfilters` value can be mangled by text tools.** Characters like `[`, `]`, `{`, `}`, `"`, `%`, and `+` appear throughout every pfilter and are meaningful in URLs. Email clients, Markdown renderers, CMS fields, Slack, and spreadsheet tools can silently strip, escape, or re-encode them — producing a URL that looks correct but fails at runtime.
+  **Special characters in the `pfilters` value can be mangled by text tools.** Characters like `[`, `]`, `{`, `}`, `"`, `%`, and `+` appear throughout every pfilter and are meaningful in URLs. Email clients, Markdown renderers, CMS fields, Slack, and spreadsheet tools can silently strip, escape, or re-encode them — producing a URL that looks correct but fails when tried.
 
   URL-encoding the entire value of the `pfilters` parameter sidesteps this: every special character becomes a safe `%XX` sequence that any tool can pass through unchanged.
 

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -82,8 +82,8 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 
 | Operand | Description | Example |
 |---|---|---|
-| `IN` | Matches any of the provided values (exact match) | `?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending","Closed"]}]` |
-| `NOT_IN` | Excludes all of the provided values | `?pfilters=[{"column":"Status","operand":"NOT_IN","values":["Deleted","Archived"]}]` |
+| `IN` | Matches any of the provided values (exact match); also works with numeric columns | `?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending","Closed"]}]` |
+| `NOT_IN` | Excludes all of the provided values; also works with numeric columns | `?pfilters=[{"column":"Status","operand":"NOT_IN","values":["Deleted","Archived"]}]` |
 | `IN_IGNORE_CASE` | Same as `IN` but case-insensitive | `?pfilters=[{"column":"Region","operand":"IN_IGNORE_CASE","values":["north america"]}]` — also matches "North America" and "NORTH AMERICA" |
 | `CONTAINS` | Matches rows where the column contains the substring | `?pfilters=[{"column":"Title","operand":"CONTAINS","values":["Q4"]}]` — matches "Q4 Report", "TORQ4MOTORS" |
 | `NOT_CONTAINS` | Matches rows where the column does not contain the substring | `?pfilters=[{"column":"Title","operand":"NOT_CONTAINS","values":["draft"]}]` |
@@ -94,12 +94,23 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 | `EQUALS` | Exact match (also works for numeric columns) | `?pfilters=[{"column":"Region","operand":"EQUALS","values":["North America"]}]` — "north america" would not match |
 | `NOT_EQUALS` | Excludes exact match (also works for numeric columns) | `?pfilters=[{"column":"Status","operand":"NOT_EQUALS","values":["N/A"]}]` |
 | `EQUALS_IGNORE_CASE` | Case-insensitive exact match | `?pfilters=[{"column":"Status","operand":"EQUALS_IGNORE_CASE","values":["active"]}]` — matches "active", "Active", and "ACTIVE" |
-| `LIKE` | SQL-style pattern match (`%` = any characters, `_` = exactly one character) | `?pfilters=[{"column":"Region","operand":"LIKE","values":["US-__"]}]` — matches "US-CA", "US-TX" but not "US-CAL" |
-| `NOT_LIKE` | Excludes rows matching the SQL-style pattern | `?pfilters=[{"column":"Title","operand":"NOT_LIKE","values":["%25archived%25"]}]` — excludes any value containing "archived" |
+| `LIKE` | SQL-style pattern match (`%` = zero or more characters, `_` = exactly one character); **matching is case-insensitive** | `?pfilters=[{"column":"Region","operand":"LIKE","values":["US-__"]}]` — matches "US-CA" and "US-TX" but not "US-C" (too short) or "US-CAL" (too long) |
+| `NOT_LIKE` | Excludes rows matching the SQL-style pattern (same wildcards and case-insensitive behavior as `LIKE`) | `?pfilters=[{"column":"Title","operand":"NOT_LIKE","values":["%25archived%25"]}]` — excludes any value containing "archived" |
 
 <Warning>
   **URL-encode special characters in `LIKE` and `NOT_LIKE` patterns.** Because pfilters are passed as URL query parameters, the `%` wildcard must be encoded as `%25` — a raw `%` will be misinterpreted as the start of a percent-encoded character and the filter will not work.
 </Warning>
+
+<Note>
+  **LIKE and NOT_LIKE pattern matching details**
+
+  | Feature | Behavior |
+  |---|---|
+  | `%` wildcard | Matches **zero or more** characters. `Apple%` matches "Apple" exactly (zero trailing characters); `%an%` matches any value containing "an"; `%` alone matches every row. |
+  | `_` wildcard | Matches **exactly one** character. `US-__` matches "US-CA" but not "US-C" (too short) or "US-CAL" (too long). Use one `_` per required character. |
+  | Case sensitivity | Matching is **case-insensitive**. `B%` and `b%` return the same results. |
+  | Bracket notation | `[charlist]` syntax (e.g. `[AB]%`) is **not supported**. The brackets are treated as literal characters — `[AB]%` only matches values that literally start with `[AB]`, not values starting with A or B. |
+</Note>
 
 <Tip>
   **Special characters in the `pfilters` value can be mangled by text tools.** Characters like `[`, `]`, `{`, `}`, `"`, `%`, and `+` appear throughout every pfilter and are meaningful in URLs. Email clients, Markdown renderers, CMS fields, Slack, and spreadsheet tools can silently strip, escape, or re-encode them — producing a URL that looks correct but fails at runtime.

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -76,8 +76,6 @@ example.domo.com/embed/pages/private/ABCDE
 
 ### Operands
 
-{/* E2E test coverage: https://github.com/domo-development/QAI/blob/main/tests/e2e/visualize/dashboards/pfilter-operators.spec.ts */}
-
 The operands you can use when writing Pfilters are listed below. The `values` field is always an array (square brackets), even when only a single value is provided.
 
 #### String operands

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -133,7 +133,7 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 
 To apply more than one filter at once, add multiple objects to the `pfilters` array:
 
-```url
+```text
 ?pfilters=[{"column":"Status","operand":"IN","values":["Active","Pending"]},{"column":"Score","operand":"GREATER_THAN","values":[50]}]
 ```
 

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -76,6 +76,8 @@ example.domo.com/embed/pages/private/ABCDE
 
 ### Operands
 
+{/* E2E test coverage: https://github.com/domo-development/QAI/blob/main/tests/e2e/visualize/dashboards/pfilter-operators.spec.ts */}
+
 The operands you can use when writing Pfilters are listed below. The `values` field is always an array (square brackets), even when only a single value is provided.
 
 #### String operands

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -177,7 +177,7 @@ If a Pfilter is written incorrectly, the unfiltered version renders and a black 
 
 The appData parameter supports passing in general types of inputs to the app. The app developer needs to watch for the parameter, parse the value, and inject it into the most relevant part of the app.
 
-For example, the value of the parameter could then auto-populate a drop-down menu in an app that selects the location. This way, the host page can avoid the delay of waiting for manual inputs. They can now deep-link to a version of the app that already has specific values filled in. Spaces should be encoded as “+” :
+For example, the value of the parameter could then auto-populate a drop-down menu in an app that selects the location. This way, the host page can avoid the delay of waiting for manual inputs. They can now deep-link to a version of the app that already has specific values filled in. Spaces should be encoded as "+" :
 
 ```html
 public.domo.com/embed/pages/abcde?appData=Salt+Lake+City

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -112,9 +112,9 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 
   **Locally:** adapt and run the following command in a browser console:
 
-  ```bash
+  ```js
   copy( encodeURI(`https://embed.domo.com/cards/ABCD?pfilters=[{"column": "Customer Segment", "operand": "IN", "values": ["Home Office"]}, {"column":"Description", "operand":"NOT_LIKE", "values":["%test%"]}]`) )
-  # https://embed.domo.com/cards/ABCD?pfilters=%5B%7B%22column%22:%20%22Customer%20Segment%22,%20%22operand%22:%20%22IN%22,%20%22values%22:%20%5B%22Home%20Office%22%5D%7D,%20%7B%22column%22:%22Description%22,%20%22operand%22:%22NOT_LIKE%22,%20%22values%22:%5B%22%25test%25%22%5D%7D%5D
+  // https://embed.domo.com/cards/ABCD?pfilters=%5B%7B%22column%22:%20%22Customer%20Segment%22,%20%22operand%22:%20%22IN%22,%20%22values%22:%20%5B%22Home%20Office%22%5D%7D,%20%7B%22column%22:%22Description%22,%20%22operand%22:%22NOT_LIKE%22,%20%22values%22:%5B%22%25test%25%22%5D%7D%5D
   ```
 </Tip>
 

--- a/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
+++ b/portal/embed/embed-in-sites-and-apps/url-parameters-in-embedded-content.mdx
@@ -95,12 +95,34 @@ The operands you can use when writing Pfilters are listed below. The `values` fi
 | `NOT_EQUALS` | Excludes exact match (also works for numeric columns) | `?pfilters=[{"column":"Status","operand":"NOT_EQUALS","values":["N/A"]}]` |
 | `EQUALS_IGNORE_CASE` | Case-insensitive exact match | `?pfilters=[{"column":"Status","operand":"EQUALS_IGNORE_CASE","values":["active"]}]` — matches "active", "Active", and "ACTIVE" |
 | `LIKE` | SQL-style pattern match (`%` = any characters, `_` = exactly one character) | `?pfilters=[{"column":"Region","operand":"LIKE","values":["US-__"]}]` — matches "US-CA", "US-TX" but not "US-CAL" |
-| `NOT_LIKE` | Excludes rows matching the SQL-style pattern | `?pfilters=[{"column":"Title","operand":"NOT_LIKE","values":["%archived%"]}]` — excludes any value containing "archived" |
+| `NOT_LIKE` | Excludes rows matching the SQL-style pattern | `?pfilters=[{"column":"Title","operand":"NOT_LIKE","values":["%25archived%25"]}]` — excludes any value containing "archived" |
+
+<Warning>
+  **URL-encode special characters in `LIKE` and `NOT_LIKE` patterns.** Because pfilters are passed as URL query parameters, the `%` wildcard must be encoded as `%25` — a raw `%` will be misinterpreted as the start of a percent-encoded character and the filter will not work.
+</Warning>
+
+<Tip>
+  **Special characters in the `pfilters` value can be mangled by text tools.** Characters like `[`, `]`, `{`, `}`, `"`, `%`, and `+` appear throughout every pfilter and are meaningful in URLs. Email clients, Markdown renderers, CMS fields, Slack, and spreadsheet tools can silently strip, escape, or re-encode them — producing a URL that looks correct but fails at runtime.
+
+  URL-encoding the entire value of the `pfilters` parameter sidesteps this: every special character becomes a safe `%XX` sequence that any tool can pass through unchanged.
+
+  **Online:** paste your pfilter value into [URLEncoder.org](https://www.urlencoder.org/) and copy the encoded result.
+
+  **Locally:** run the following command, paste your full URL at the prompt, and press Enter:
+
+  ```bash
+  node -e "const rl=require('readline').createInterface({input:process.stdin,output:process.stdout});rl.question('Paste full URL: ',v=>{console.log(encodeURI(v));rl.close()})"
+  ```
+
+  Use the encoded URL as-is.
+</Tip>
 
 #### Numeric operands
 
 | Operand | Description | Example |
 |---|---|---|
+| `EQUALS` | Exact match against a single numeric value (also listed under string operands) | `?pfilters=[{"column":"Year","operand":"EQUALS","values":[2024]}]` |
+| `NOT_EQUALS` | Excludes rows with an exact numeric value (also listed under string operands) | `?pfilters=[{"column":"Year","operand":"NOT_EQUALS","values":[2024]}]` |
 | `GREATER_THAN` | Matches rows where the column value is greater than the provided number | `?pfilters=[{"column":"Revenue","operand":"GREATER_THAN","values":[100]}]` |
 | `GREAT_THAN_EQUALS_TO` | Matches rows where the column value is greater than or equal to the provided number | `?pfilters=[{"column":"Score","operand":"GREAT_THAN_EQUALS_TO","values":[0]}]` — matches zero and all positive values |
 | `LESS_THAN` | Matches rows where the column value is less than the provided number | `?pfilters=[{"column":"Revenue","operand":"LESS_THAN","values":[1000]}]` |


### PR DESCRIPTION
## Summary

- Replaces the sparse 9-item bullet list of operands with two organized reference tables (string and numeric)
- Covers all supported operands: `IN`, `NOT_IN`, `IN_IGNORE_CASE`, `CONTAINS`, `NOT_CONTAINS`, `STARTS_WITH`, `NOT_STARTS_WITH`, `ENDS_WITH`, `NOT_ENDS_WITH`, `EQUALS`, `NOT_EQUALS`, `EQUALS_IGNORE_CASE`, `LIKE`, `NOT_LIKE`, `GREATER_THAN`, `GREAT_THAN_EQUALS_TO`, `LESS_THAN`, `LESS_THAN_EQUALS_TO`, `BETWEEN`, `NOT_BETWEEN`
- Documents the correct `values` format for each operand (array of strings vs. single value vs. two-value range for `BETWEEN`)
- Adds concrete URL examples for `CONTAINS`, `BETWEEN`, `LIKE`, and multi-filter usage

## Test plan

- [x] Verify tables render correctly in the docs preview
- [x] Confirm all operand names match the platform implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)