### PR TITLE
Require excerpt frontmatter field in articles

### DIFF
--- a/Domo-KB-Style-Guide.mdx
+++ b/Domo-KB-Style-Guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Domo KB Style Guide"
+excerpt: "Standards and conventions for writing clear, consistent Domo Knowledge Base documentation."
 ---
 
 ## Intro
@@ -16,6 +17,21 @@ If you can't find an answer in any of these sources, consult with the Knowledge 
 ## Article Design
 
 This section includes content and page design standards for creating Knowledge Base content. These standards are not exhaustive and can be added to as needed.
+
+### Frontmatter
+
+Every article must include an `excerpt` field in its YAML frontmatter, directly below the `title`. The excerpt is a single sentence summarizing what the article covers — think of it as the "what's in this file" hint for future writers, PMs scanning the repo, and AI tools that need quick, accurate context without parsing the full article body.
+
+````mdx
+---
+title: "Create and Use Data Models"
+excerpt: "Define relationships between DataSets once and reuse them across Domo for consistent metrics and faster analysis."
+---
+````
+
+Keep the excerpt to a single sentence and use the same terminology as the article body, so the summary stays accurate as the article evolves.
+
+Do not use a `description` field in place of `excerpt`. Mintlify renders `description` on the published page, which duplicates the Intro section. The `excerpt` field, by contrast, is invisible on the rendered site and exists purely as repo-level metadata.
 
 ### Article Structure
 

--- a/New-Article-Template.mdx
+++ b/New-Article-Template.mdx
@@ -1,5 +1,6 @@
 ---
 title: "New Article Template"
+excerpt: "Brief one-sentence summary of what this article covers."
 ---
 
 {/*


### PR DESCRIPTION
## Summary
- Add a new `### Frontmatter` subsection to `Domo-KB-Style-Guide.mdx` requiring an `excerpt:` field directly under `title:` in every article's YAML frontmatter. Explains that the excerpt is repo-level metadata (invisible on the rendered site) for fast scanning by writers, PMs, and AI tools, and clarifies why we don't use Mintlify's `description:` field.
- Add an `excerpt:` placeholder to `New-Article-Template.mdx` so the convention is baked into every new article.
- Add a real excerpt to the style guide's own frontmatter, leading by example.

This is the rules-only change. A follow-up will backfill `excerpt:` into the ~3,240 existing articles across `s/article/`, `ja/s/article/`, `fr/s/article/`, `es/s/article/`, and `de/s/article/`.

## Test plan
- [ ] Confirm the new `### Frontmatter` section renders correctly in Mintlify preview.
- [ ] Confirm the style guide's own `excerpt:` field does not render visibly on the published page.
- [ ] Confirm the template's `excerpt:` placeholder appears correctly in the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)