### PR TITLE
Backfill excerpt frontmatter on all French KB articles

### DIFF
--- a/fr/s/article/000005174.mdx
+++ b/fr/s/article/000005174.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version d'octobre 2022"
+excerpt: "Notes de version d'octobre 2022 de Domo, incluant l'éditeur Beast Mode amélioré, les variables, le mode de présentation des histoires et les mises à jour mobiles."
 ---
 
 ## Améliorations

--- a/fr/s/article/000005256.mdx
+++ b/fr/s/article/000005256.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de mars 2023"
+excerpt: "Notes de version de mars 2023 de Domo, avec modules Microsoft Office, attributs de groupes, calculs de tableaux et nouveaux types de graphiques."
 ---
 
 ## Dojo devient le Forum communautaire

--- a/fr/s/article/000005308.mdx
+++ b/fr/s/article/000005308.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de juillet 2023"
+excerpt: "Notes de version de juillet 2023 de Domo, avec déclenchement avancé des DataFlows, traitement partitionné Magic ETL et amplificateur de cloud."
 ---
 
 ---

--- a/fr/s/article/000005377.mdx
+++ b/fr/s/article/000005377.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version d'octobre 2023"
+excerpt: "Notes de version d'octobre 2023 de Domo, avec la couche de service d'IA, la bibliothèque de ressources et l'éditeur Beast Mode avec IA."
 ---
 
 ---

--- a/fr/s/article/000005430.mdx
+++ b/fr/s/article/000005430.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de janvier 2024"
+excerpt: "Notes de version de janvier 2024 de Domo, avec Domo.AI, Assistant d'IA Beast Mode, flux de travail, moteur de code et files d'attente."
 ---
 
 ---

--- a/fr/s/article/000005459.mdx
+++ b/fr/s/article/000005459.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de mars 2024"
+excerpt: "Notes de version de mars 2024 de Domo, avec Studio d'applications, navigation personnalisée, Magic ETL et ResponsibleGPT."
 ---
 
 #### Nouvelles fonctionnalités

--- a/fr/s/article/000005504.mdx
+++ b/fr/s/article/000005504.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de mai 2024"
+excerpt: "Notes de version de mai 2024 de Domo, avec alertes de rapports planifiés, graphique à barres haut-bas et administration de la passerelle d'API."
 ---
 
 ## Nouvelles fonctionnalités

--- a/fr/s/article/000005553.mdx
+++ b/fr/s/article/000005553.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de mars juillet"
+excerpt: "Notes de version de Domo avec DomoGPT, mosaïque d'inférence de modèle d'IA, mises à jour d'Analyzer et améliorations des flux de travail."
 ---
 
 ## Nouvelles fonctionnalités

--- a/fr/s/article/000005698.mdx
+++ b/fr/s/article/000005698.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de septembre 2024"
+excerpt: "Notes de version de septembre 2024 de Domo, avec Conversation par IA, préparation à l'IA et nouvelles fonctionnalités du Studio d'applications."
 ---
 
 ## Mises à jour d'octobre 2024

--- a/fr/s/article/000005784.mdx
+++ b/fr/s/article/000005784.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de novembre 2024"
+excerpt: "Notes de version de novembre 2024 de Domo, avec planification avancée de l'actualité des données, requêtes dans les flux de travail et nouveau rapport DomoStats."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/000005812.mdx
+++ b/fr/s/article/000005812.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de janvier 2025"
+excerpt: "Notes de version de janvier 2025 de Domo, avec mises à jour du journal d'activité, Conversation par IA, Cloud Amplifier et nouveaux connecteurs."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/000005848.mdx
+++ b/fr/s/article/000005848.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de mars 2025"
+excerpt: "Notes de version de mars 2025 de Domo, avec Cloud Amplifier, agents d'IA dans les flux de travail et nouvelles fonctionnalités de Magic ETL."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/000005877.mdx
+++ b/fr/s/article/000005877.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de mai 2025"
+excerpt: "Notes de version de mai 2025 de Domo, avec connecteur multicompte Facebook, ajout de privilèges, modèles d'instance et mise à jour des tableaux de bord v5."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/000005904.mdx
+++ b/fr/s/article/000005904.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de juilliet 2025"
+excerpt: "Notes de version de juillet 2025 de Domo, avec autorisations d'actualisation des données, liste d'autorisation des rôles et nouvelle configuration SSO."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/000005924.mdx
+++ b/fr/s/article/000005924.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de septembre 2025"
+excerpt: "Notes de version de septembre 2025 de Domo, avec tableau de consommation d'IA, masquage de colonnes PDP et fonctions de fenêtre SQL."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/000006035.mdx
+++ b/fr/s/article/000006035.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de novembre 2025"
+excerpt: "Notes de version de novembre 2025 de Domo, avec composants d'application, intégrations cloud Azure SQL et MySQL et Magic ETL dans BigQuery."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/360042922994.mdx
+++ b/fr/s/article/360042922994.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Création d'un DataFlow SQL"
+excerpt: "Créez un DataFlow SQL dans le Data Center en sélectionnant des DataSets d'entrée, en appliquant des transformations et en définissant un DataSet en sortie."
 ---
 
 Affichage du résumé de la page

--- a/fr/s/article/360042926154.mdx
+++ b/fr/s/article/360042926154.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Meilleures pratiques de gestion des DataSets"
+excerpt: "Adoptez les meilleures pratiques de Domo pour nommer, décrire et gouverner les DataSets afin de garantir la cohérence et la traçabilité des données."
 ---
 
 Affichage du résumé de la page

--- a/fr/s/article/360042934294.mdx
+++ b/fr/s/article/360042934294.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Création et gestion des groupes d'utilisateurs"
+excerpt: "Créez et gérez des groupes d'utilisateurs dans les Paramètres d'administrateur Domo pour contrôler l'accès aux cartes, pages et contenus partagés."
 ---
 
 ## Introduction

--- a/fr/s/article/360042934614.mdx
+++ b/fr/s/article/360042934614.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Création et suppression des politiques PDP"
+excerpt: "Créez et gérez des politiques PDP sur les DataSets pour filtrer les données affichées aux utilisateurs et groupes spécifiques dans Domo."
 ---
 
 Affichage du résumé de la page

--- a/fr/s/article/360042934834.mdx
+++ b/fr/s/article/360042934834.mdx
@@ -1,5 +1,6 @@
 ---
 title: "October 2019 Release Notes"
+excerpt: "Notes de version d'octobre 2019 de Domo, avec moteur d'automatisation pour l'entreprise, actions d'alerte et navigation mise à jour."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/360042934974.mdx
+++ b/fr/s/article/360042934974.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Octobre 2018, version 1"
+excerpt: "Notes de version d'octobre 2018 de Domo, avec contenu certifié, actions de science des données et de script dans ETL, et version bêta de Workbench 5."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/360043428293.mdx
+++ b/fr/s/article/360043428293.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Combiner des DataSets à l'aide d'une DataFusion"
+excerpt: "Combinez plusieurs DataSets dans une DataFusion en ajoutant des colonnes ou des lignes afin de produire un DataSet en sortie unifié."
 ---
 
 Affichage du résumé de la page

--- a/fr/s/article/360043430513.mdx
+++ b/fr/s/article/360043430513.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Création d'une alerte personnalisée pour une carte KPI"
+excerpt: "Créez des alertes personnalisées sur une carte KPI Domo en définissant des mesures, des conditions et des seuils pour recevoir des notifications par e-mail ou SMS."
 ---
 
 ## Introduction

--- a/fr/s/article/360043434433.mdx
+++ b/fr/s/article/360043434433.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Connecteur Facebook"
+excerpt: "Configurez le connecteur Facebook de Domo via OAuth pour importer dans un DataSet des rapports sur les pages, les adeptes et les impressions."
 ---
 
 Affichage du résumé de la page

--- a/fr/s/article/360043437793.mdx
+++ b/fr/s/article/360043437793.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Partage de contenu à l'aide de diaporamas"
+excerpt: "Créez des diaporamas et des publications Domo pour partager des cartes en kiosque, sur le Web ou par e-mail, avec planification et codes d'accès."
 ---
 
 ## Introduction

--- a/fr/s/article/360043439873.mdx
+++ b/fr/s/article/360043439873.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Version 1 - janvier 2019"
+excerpt: "Notes de version de janvier 2019 de Domo, avec Workbench 5, filtrage des pages Vue d'ensemble, approbation de groupes et indexation des DataFlows SQL."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/360043440673.mdx
+++ b/fr/s/article/360043440673.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Version 1 janvier 2017"
+excerpt: "Notes de version de janvier 2017 de Domo, avec nouveaux outils d'interaction CSR, options Administrateur en bloc pour les Pages et Cartes."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/360055244114.mdx
+++ b/fr/s/article/360055244114.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de juillet 2020"
+excerpt: "Notes de version de juillet 2020 de Domo, avec améliorations des cartes de tableaux, jauge multivaleur et options de carte de latitude-longitude."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/360061873754.mdx
+++ b/fr/s/article/360061873754.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de l'automne 2020"
+excerpt: "Notes de version de l'automne 2020 de Domo, avec Gestionnaire Beast Mode, planification améliorée des connecteurs et applications Code Block."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/4403173731863.mdx
+++ b/fr/s/article/4403173731863.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de mars 2021"
+excerpt: "Notes de version de mars 2021 de Domo, avec IDE de connecteur de réécriture, page d'accueil Science des données, filtrer les vues et SDK Python et R."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/4409045382935.mdx
+++ b/fr/s/article/4409045382935.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version de juillet 2021"
+excerpt: "Notes de version de juillet 2021 de Domo, avec unions dans les vues DataSet, intégration Analyzer, centre de lancement et Workbench 5.1."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/4425111066903.mdx
+++ b/fr/s/article/4425111066903.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version d'octobre 2021"
+excerpt: "Notes de version d'octobre 2021 de Domo, avec Nouvelle Magic ETL, planification améliorée des DataFlows et nouvel assistant de connecteur."
 ---
 
 ## Nouvelles fonctionnalités et optimisations

--- a/fr/s/article/Current-Release-Notes.mdx
+++ b/fr/s/article/Current-Release-Notes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notes de version actuelles"
+excerpt: "Notes de version actuelles de Domo, avec composants d'application, intégrations cloud Azure SQL et MySQL et Magic ETL dans BigQuery."
 ---
 
 ## Nouvelles fonctionnalités et optimisations


### PR DESCRIPTION
## Summary
- Adds the `excerpt:` frontmatter field to all 34 French KB articles under `fr/s/article/`, bringing the French corpus into compliance with the convention added in #224.
- Each excerpt is a single French sentence (under ~150 characters) summarizing what the article covers. Domo product/feature names (DataSet, Beast Mode, Magic ETL, Workbench, DataFlow, etc.) are kept in their English form per house convention.
- Companion to #225 (English) and #226 (Japanese).

## Review notes
- Diff: 34 single-line additions, one new `excerpt:` line per file under `title:`. No other content was modified.
- The `excerpt:` field is repo-only metadata; Mintlify does not render it on the published page.

## Test plan
- [x] Spot-check ~5 random French articles for excerpt accuracy and natural French phrasing.
- [x] Confirm Mintlify preview renders normally with no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)