### PR TITLE
Backfill excerpt frontmatter on all Spanish KB articles

### DIFF
--- a/es/s/article/000005174.mdx
+++ b/es/s/article/000005174.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la versión de octubre de 2022"
+excerpt: "Mejoras y nuevas funciones de la versión de octubre de 2022, incluidas variables de Beast Mode, Modo de presentación de historias y tableros móviles mejorados."
 ---
 
 ## Mejoras

--- a/es/s/article/000005256.mdx
+++ b/es/s/article/000005256.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la version de marzo de 2023"
+excerpt: "Funciones de la versión de marzo de 2023, incluidos los complementos de Microsoft Office, atributos personalizados para grupos y nuevos tipos de diagramas."
 ---
 
 ## Dojo pasa a ser los Foros de la comunidad

--- a/es/s/article/000005308.mdx
+++ b/es/s/article/000005308.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la versión de julio de 2023"
+excerpt: "Mejoras de la plataforma y funciones nuevas de julio de 2023, incluidos los complementos de MS Office, Flex Map v2 y activación avanzada de DataFlow."
 ---
 
 ---

--- a/es/s/article/000005377.mdx
+++ b/es/s/article/000005377.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2023| Notas de la versión de octubre"
+excerpt: "Funciones de la versión de octubre de 2023, incluida la capa de servicio de IA, biblioteca de componentes, campañas y mejoras de Analyzer."
 ---
 
 ---

--- a/es/s/article/000005430.mdx
+++ b/es/s/article/000005430.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Notas de la versión de enero"
+excerpt: "Funciones de la versión de enero de 2024, incluido Domo.AI, Flujos de trabajo, Formularios, Colas y conectores JSON sin código."
 ---
 
 ---

--- a/es/s/article/000005459.mdx
+++ b/es/s/article/000005459.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Notas de la versión de marzo"
+excerpt: "Funciones de la versión de marzo de 2024, incluidos la aplicación Studio, Magic ETL, ResponsibleGPT y mejoras de Domo Everywhere."
 ---
 
 #### Nuevas funciones

--- a/es/s/article/000005504.mdx
+++ b/es/s/article/000005504.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Notas de la versión de mayo"
+excerpt: "Funciones de la versión de mayo de 2024, incluidas alertas para informes programados, diagrama alto-bajo horizontal y administración de la API gateway."
 ---
 
 ## Nuevas funciones

--- a/es/s/article/000005553.mdx
+++ b/es/s/article/000005553.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Notas de la versión de julio"
+excerpt: "Funciones de la versión de julio de 2024, incluido DomoGPT, mejoras de Analyzer, actualizaciones de Flujos de trabajo y el editor del código profesional."
 ---
 
 ## Nuevas funciones

--- a/es/s/article/000005698.mdx
+++ b/es/s/article/000005698.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Notas de la versión de septiembre"
+excerpt: "Funciones de septiembre y octubre de 2024, incluidos el Chat de IA, Preparación de IA, ventanas emergentes de App Studio y exportaciones de App Studio Embed."
 ---
 
 ## Actualizaciones de octubre de 2024

--- a/es/s/article/000005784.mdx
+++ b/es/s/article/000005784.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Notas de la versión de noviembre"
+excerpt: "Funciones de la versión de noviembre de 2024, incluidos programación avanzada de actualidad de datos, consulta de Flujos de trabajo y editor del código profesional."
 ---
 
 ## Nuevas funciones y mejoras

--- a/es/s/article/000005812.mdx
+++ b/es/s/article/000005812.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Notas de la versión de enero"
+excerpt: "Funciones de la versión de enero de 2025, incluidas mejoras de App Studio, Cloud Amplifier, conectores y nuevas opciones de Magic ETL."
 ---
 
 ## Nuevas funciones y mejoras

--- a/es/s/article/000005848.mdx
+++ b/es/s/article/000005848.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Notas de la versión de marzo"
+excerpt: "Funciones de la versión de marzo de 2025, incluido el nuevo elemento de tabla de App Studio, agentes de IA en Flujos de trabajo y mejoras de Magic ETL."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/000005877.mdx
+++ b/es/s/article/000005877.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Notas de la versión de mayo"
+excerpt: "Funciones de la versión de mayo de 2025, incluido el conector avanzado de Facebook Ads, elevación de cambios confidenciales y plantillas de instancias."
 ---
 
 ## Nuevas funciones y mejoras

--- a/es/s/article/000005904.mdx
+++ b/es/s/article/000005904.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Notas de la versión de julio"
+excerpt: "Funciones de la versión de julio de 2025, incluidos permisos de actualización de datos, lista de funciones permitidas y nueva configuración de SSO."
 ---
 
 ## Nuevas funciones y mejoras

--- a/es/s/article/000005924.mdx
+++ b/es/s/article/000005924.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Notas de la versión de septiembre"
+excerpt: "Funciones de la versión de septiembre de 2025, incluidos el índice de utilización de IA, enmascaramiento de columnas PDP y funciones de ventana en SQL."
 ---
 
 ## Nuevas funciones y mejoras

--- a/es/s/article/000006035.mdx
+++ b/es/s/article/000006035.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Notas de la versión de noviembre"
+excerpt: "Funciones de la versión de noviembre de 2025, incluidos los nuevos componentes de aplicación arrastrar y soltar y soporte de solo lectura para Azure SQL y MySQL."
 ---
 
 ## Nuevas funciones y mejoras

--- a/es/s/article/360042922994.mdx
+++ b/es/s/article/360042922994.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Creación de un DataFlow de SQL (Lenguaje de consulta estructurado)"
+excerpt: "Cree un DataFlow con consultas SQL en Data Center para transformar DataSets de entrada y generar DataSets de salida con MySQL o Redshift."
 ---
 
 ## Introducción

--- a/es/s/article/360042934294.mdx
+++ b/es/s/article/360042934294.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Creación y administración de grupos de usuarios"
+excerpt: "Cree y administre grupos de usuarios de Domo en la Configuración del administrador para conceder acceso a tarjetas y páginas a varios usuarios a la vez."
 ---
 
 ## Introducción

--- a/es/s/article/360042934614.mdx
+++ b/es/s/article/360042934614.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Crear y eliminar políticas de permisos personalizados de datos"
+excerpt: "Cree y elimine políticas de permisos personalizados de datos en los DataSets para filtrar las filas que ven los usuarios y grupos específicos."
 ---
 
 ## Introducción

--- a/es/s/article/360042934834.mdx
+++ b/es/s/article/360042934834.mdx
@@ -1,5 +1,6 @@
 ---
 title: "October 2019 Release Notes"
+excerpt: "Funciones de la versión de octubre de 2019, incluidas acciones de alerta para Webhook y Tareas y la nueva navegación actualizada de Domo."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/360043428293.mdx
+++ b/es/s/article/360043428293.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Combinación de DataSets mediante DataFusion"
+excerpt: "Combine DataSets en DataFusion utilizando los métodos Agregar columnas o Agregar filas para crear un nuevo DataSet de salida unificado."
 ---
 
 ## Introducción

--- a/es/s/article/360043430513.mdx
+++ b/es/s/article/360043430513.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Creación de una alerta personalizada para una tarjeta de indicador de desempeño clave"
+excerpt: "Configure una alerta personalizada en una tarjeta de indicador de desempeño clave para recibir notificaciones cuando se cumplan las condiciones especificadas."
 ---
 
 ## Introducción

--- a/es/s/article/360043434433.mdx
+++ b/es/s/article/360043434433.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Conector de Facebook"
+excerpt: "Use el conector de Facebook para extraer en Domo datos de publicaciones, seguidores, impresiones y métricas de cuenta de los últimos 30 días."
 ---
 
 ## Introducción

--- a/es/s/article/360043437793.mdx
+++ b/es/s/article/360043437793.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Compartir contenido mediante presentaciones"
+excerpt: "Cree y comparta presentaciones de tarjetas de Domo, mediante publicaciones exportables o presentaciones de una sola página para paneles y monitores."
 ---
 
 ## Introducción

--- a/es/s/article/360043439873.mdx
+++ b/es/s/article/360043439873.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versión de enero de 2019 1"
+excerpt: "Funciones de la versión de enero de 2019, incluidos Workbench 5, filtros de página en resumen y favoritos, y aprobación de certificación por grupos."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/360055244114.mdx
+++ b/es/s/article/360055244114.mdx
@@ -1,5 +1,6 @@
 ---
 title: "July 2020 Release Notes"
+excerpt: "Funciones de la versión de julio de 2020, incluidas mejoras de tarjetas de tabla y mapa, paginación e indicador de valor múltiple con opciones de formato."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/360061873754.mdx
+++ b/es/s/article/360061873754.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la versión de otoño de 2020"
+excerpt: "Funciones del lanzamiento de otoño de 2020, incluidos el archivado de Beast Modes, programación mejorada de conectores y aplicaciones de bloque de código."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/4403173731863.mdx
+++ b/es/s/article/4403173731863.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la versión de marzo de 2021"
+excerpt: "Funciones de la versión de marzo de 2021, incluidos el IDE de conector de reescritura, página principal de ciencia de datos y vistas de filtro."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/4409045382935.mdx
+++ b/es/s/article/4409045382935.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la versión de julio de 2021"
+excerpt: "Funciones de la versión de julio de 2021, incluidas uniones de Vistas de DataSet, integración con Analyzer y mejoras de Workbench 5.1."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/4425111066903.mdx
+++ b/es/s/article/4425111066903.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la versión de octubre de 2021"
+excerpt: "Funciones de la versión de octubre de 2021, incluida la nueva Magic ETL con nuevos iconos y mejoras de la programación de DataFlow."
 ---
 
 ## Nuevas características y mejoras

--- a/es/s/article/Current-Release-Notes.mdx
+++ b/es/s/article/Current-Release-Notes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Notas de la versión actual"
+excerpt: "Funciones de la versión actual de Domo, incluidos los nuevos componentes de aplicación arrastrar y soltar y soporte de solo lectura para Azure SQL y MySQL."
 ---
 
 ## Nuevas funciones y mejoras


### PR DESCRIPTION
## Summary
- Adds the `excerpt:` frontmatter field to all 31 Spanish KB articles under `es/s/article/`, bringing the Spanish corpus into compliance with the convention added in #224.
- Each excerpt is a single Spanish sentence (under ~150 characters) summarizing what the article covers. Domo product/feature names (DataSet, Beast Mode, Magic ETL, etc.) are kept in their English form per house convention.
- Companion to #225 (English), #226 (Japanese), and #227 (French).

## Review notes
- Diff: 31 single-line additions, one new `excerpt:` line per file under `title:`. No other content was modified.
- The `excerpt:` field is repo-only metadata; Mintlify does not render it on the published page.

## Test plan
- [x] Spot-check ~5 random Spanish articles for excerpt accuracy and natural Spanish phrasing.
- [x] Confirm Mintlify preview renders normally with no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)