### PR TITLE
Backfill excerpt frontmatter on all German KB articles

### DIFF
--- a/de/s/article/000005174.mdx
+++ b/de/s/article/000005174.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versionshinweise Oktober 2022"
+excerpt: "Übersicht der Oktober-2022-Version mit Verbesserungen am Beast Mode-Editor, neuen Variablen, Geschichtenpräsentationsmodus und mobilen Updates."
 ---
 
 ## Verbesserungen

--- a/de/s/article/000005256.mdx
+++ b/de/s/article/000005256.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versionshinweise für März 2023"
+excerpt: "Übersicht der März-2023-Version mit Microsoft Office-Add-ins, dynamischen Gruppenattributen, Tabellenberechnungen und neuen Diagrammtypen."
 ---
 
 ## Dojo wird zum Community-Forum

--- a/de/s/article/000005308.mdx
+++ b/de/s/article/000005308.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versionshinweise für Juli 2023"
+excerpt: "Übersicht der Juli-2023-Version mit Plattformverbesserungen, neuen Funktionen wie DataFlow-Auslösern und Magic ETL sowie Premium-Updates."
 ---
 
 ---

--- a/de/s/article/000005377.mdx
+++ b/de/s/article/000005377.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2023 | Versionshinweise Oktober"
+excerpt: "Übersicht der Oktober-2023-Version mit KI-Dienst-Layer, Asset Library, Analyzer-Updates, Campaigns und Beta-Ankündigungen zur KI."
 ---
 
 ---

--- a/de/s/article/000005430.mdx
+++ b/de/s/article/000005430.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Versionshinweise Januar"
+excerpt: "Übersicht der Januar-2024-Version mit Domo.AI, Arbeitsabläufen, Code-Engine, Magic ETL-Diagrammansicht und Domo Bricks-Verbesserungen."
 ---
 
 ---

--- a/de/s/article/000005459.mdx
+++ b/de/s/article/000005459.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Versionshinweise Marsch"
+excerpt: "Übersicht der März-2024-Version mit App Studio, ResponsibleGPT, Magic ETL Concat Distinct, Cloud Amplifier und Workbench Enterprise."
 ---
 
 #### Neue Funktionen

--- a/de/s/article/000005504.mdx
+++ b/de/s/article/000005504.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Versionshinweise Mai"
+excerpt: "Übersicht der Mai-2024-Version mit geplanten Berichten als Mitteilung, horizontalem Hoch-Niedrig-Diagramm und API-Gateway-Verwaltung."
 ---
 
 ---

--- a/de/s/article/000005553.mdx
+++ b/de/s/article/000005553.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Versionshinweise Juli"
+excerpt: "Übersicht der Juli-2024-Version mit DomoGPT, KI-Modell-Rückschlusskachel, Analyzer- und Arbeitsablauf-Updates sowie Pro-Code-Editor-Beta."
 ---
 
 ## Neue Funktionen

--- a/de/s/article/000005698.mdx
+++ b/de/s/article/000005698.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Versionshinweise September"
+excerpt: "Übersicht der September-2024-Version mit allgemein verfügbarem KI-Chat, KI-Bereitschaft für DataSets und App Studio-Erweiterungen."
 ---
 
 ---

--- a/de/s/article/000005784.mdx
+++ b/de/s/article/000005784.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2024 | Versionshinweise November"
+excerpt: "Übersicht der November-2024-Version mit erweiterter Zeitplanung, Pro-Code-Editor, Bilddiagramm und universellem KI-Prognosemodell."
 ---
 
 ## Neue Funktionen und Verbesserungen

--- a/de/s/article/000005812.mdx
+++ b/de/s/article/000005812.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Versionshinweise Januar"
+excerpt: "Übersicht der Januar-2025-Version mit Aktivitätsprotokoll-Updates, App Studio-Verbesserungen, Cloud Amplifier-Writeback und MS Fabric-Konnektor."
 ---
 
 ## Neue Funktionen und Verbesserungen

--- a/de/s/article/000005848.mdx
+++ b/de/s/article/000005848.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Versionshinweise Marsch"
+excerpt: "Übersicht der März-2025-Version mit neuem Tabellenelement in App Studio, KI-Agenten in Arbeitsabläufen, Magic ETL und Cloud Amplifier."
 ---
 
 ## Neue Funktionen und Verbesserungen

--- a/de/s/article/000005877.mdx
+++ b/de/s/article/000005877.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Versionshinweise Mai"
+excerpt: "Übersicht der Mai-2025-Version mit erweitertem Facebook-Anzeigen-Konnektor, sensiblen Berechtigungserweiterungen, Instanzvorlagen und Dashboard v5."
 ---
 
 ---

--- a/de/s/article/000005904.mdx
+++ b/de/s/article/000005904.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Versionshinweise Juli"
+excerpt: "Übersicht der Juli-2025-Version mit Datenaktualisierungs-Berechtigungen, Zulassungsliste für Rollen und neuer SSO-Konfigurationsoberfläche."
 ---
 
 ---

--- a/de/s/article/000005924.mdx
+++ b/de/s/article/000005924.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Versionshinweise September"
+excerpt: "Übersicht der September-2025-Version mit der Tabelle für KI-Verbrauchsraten, PDB-Spaltenmaskierung und Fensterfunktionen in der SQL-Kachel."
 ---
 
 ---

--- a/de/s/article/000006035.mdx
+++ b/de/s/article/000006035.mdx
@@ -1,5 +1,6 @@
 ---
 title: "2025 | Versionshinweise November"
+excerpt: "Übersicht der November-2025-Version mit Drag-and-Drop-App-Komponenten und schreibgeschützter Cloud-Integration für Azure SQL und MySQL."
 ---
 
 ---

--- a/de/s/article/360042922994.mdx
+++ b/de/s/article/360042922994.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Erstellen eines SQL-DataFlows"
+excerpt: "Erstellen Sie einen SQL-DataFlow im Data Center mit MySQL-Abfragen, um Eingabe-DataSets zu transformieren und Ausgabe-DataSets zu generieren."
 ---
 
 Ansicht der Seitenzusammenfassung

--- a/de/s/article/360042926154.mdx
+++ b/de/s/article/360042926154.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Optimales Vorgehen zum Verwalten von DataSets"
+excerpt: "Befolgen Sie bewährte Verfahren für die Benennung, Beschreibung und Datensteuerung von DataSets sowie für die Pflege von DataFlows in Domo."
 ---
 
 Ansicht der Seitenzusammenfassung

--- a/de/s/article/360042934294.mdx
+++ b/de/s/article/360042934294.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Erstellen und Verwalten von Benutzergruppen"
+excerpt: "Erstellen, umbenennen und löschen Sie Benutzergruppen in den Administratoreinstellungen, um Inhaltszugriff für Domo-Benutzer zu verwalten."
 ---
 
 ## Einführung

--- a/de/s/article/360042934614.mdx
+++ b/de/s/article/360042934614.mdx
@@ -1,5 +1,6 @@
 ---
 title: "PDP-Richtlinien erstellen und löschen"
+excerpt: "Erstellen und löschen Sie PDP-Richtlinien im Data Center, um Daten in DataSets für bestimmte Benutzer und Gruppen zu filtern."
 ---
 
 Ansicht der Seitenzusammenfassung

--- a/de/s/article/360042934834.mdx
+++ b/de/s/article/360042934834.mdx
@@ -1,5 +1,6 @@
 ---
 title: "October 2019 Release Notes"
+excerpt: "Übersicht der Oktober-2019-Version mit Mitteilungsaktionen der Business Automation Engine und aktualisierter Navigationsoberfläche."
 ---
 
 ## Neue Merkmale und Verbesserungen

--- a/de/s/article/360042934974.mdx
+++ b/de/s/article/360042934974.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Oktober 2018 Version 1"
+excerpt: "Übersicht der Oktober-2018-Version mit zertifizierten Inhalten und Data-Science- sowie Skriptaktionen für ETL-DataFlows."
 ---
 
 ## Neue Funktionen und Verbesserungen

--- a/de/s/article/360043428293.mdx
+++ b/de/s/article/360043428293.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Kombinieren von DataSets mit DataFusion"
+excerpt: "Kombinieren Sie DataSets mit DataFusion, indem Sie Spalten zusammenführen oder Reihen aus mehreren DataSets in ein einzelnes DataSet anhängen."
 ---
 
 Ansicht der Seitenzusammenfassung

--- a/de/s/article/360043430513.mdx
+++ b/de/s/article/360043430513.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Erstellen einer benutzerdefinierten Mitteilung für eine KPI-Karte"
+excerpt: "Erstellen Sie eine benutzerdefinierte Mitteilung für eine KPI-Karte mit Bedingungen, Schwellenwerten und Benachrichtigungen per E-Mail oder SMS."
 ---
 
 ## Einführung

--- a/de/s/article/360043434433.mdx
+++ b/de/s/article/360043434433.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Facebook-Konnektor"
+excerpt: "Konfigurieren Sie den Facebook-Konnektor von Domo, um Posts, Seiten-Fans, Eindrücke und weitere Einblicke per OAuth in ein DataSet abzurufen."
 ---
 
 Ansicht der Seitenzusammenfassung

--- a/de/s/article/360043437793.mdx
+++ b/de/s/article/360043437793.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Inhalte mithilfe von Diashows freigeben"
+excerpt: "Erstellen und verwalten Sie Domo-Publikationen und Seiten-Diashows, um Karten in Präsentationen, auf Wandanzeigen oder als Berichte zu teilen."
 ---
 
 ## Einführung

--- a/de/s/article/360043439873.mdx
+++ b/de/s/article/360043439873.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Januar 2019 Version 1"
+excerpt: "Übersicht der Januar-2019-Version mit Workbench 5, Seitenfilterung, Gruppengenehmigung für zertifizierten Content und neuen Grants."
 ---
 
 ## Neue Funktionen und Verbesserungen

--- a/de/s/article/360055244114.mdx
+++ b/de/s/article/360055244114.mdx
@@ -1,5 +1,6 @@
 ---
 title: "July 2020 Release Notes"
+excerpt: "Übersicht der Juli-2020-Version mit Kartenverbesserungen für Tabellen, Mehrwertindikatoren und weiteren Optimierungen der Diagrammoptionen."
 ---
 
 ## Neue Merkmale und Verbesserungen

--- a/de/s/article/360061873754.mdx
+++ b/de/s/article/360061873754.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versionshinweise für Herbst 2020"
+excerpt: "Übersicht der Herbst-2020-Version mit Beast Mode-Manager-Verbesserungen, neuem Konnektor-Scheduler und Codeblock-Apps."
 ---
 
 ## Neue Merkmale und Verbesserungen

--- a/de/s/article/4403173731863.mdx
+++ b/de/s/article/4403173731863.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versionshinweise für März 2021"
+excerpt: "Übersicht der März-2021-Version mit Writeback-Konnektor-IDE, Data Science-Homepage, Filteransichten und SDK-Verbesserungen."
 ---
 
 ## Neue Merkmale und Verbesserungen

--- a/de/s/article/4409045382935.mdx
+++ b/de/s/article/4409045382935.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versionshinweise für Juli 2021"
+excerpt: "Übersicht der Juli-2021-Version mit DataSet-Ansichten-Unions, Analyzer-Integration, Launch-Center und Workbench 5.1-Partitionsunterstützung."
 ---
 
 ## Neue Merkmale und Verbesserungen

--- a/de/s/article/4425111066903.mdx
+++ b/de/s/article/4425111066903.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versionshinweise Oktober 2021"
+excerpt: "Übersicht der Oktober-2021-Version mit der neuen Magic ETL und erweiterten DataFlow-Planungsoptionen für flexiblere Zeitpläne."
 ---
 
 ## Neue Merkmale und Verbesserungen

--- a/de/s/article/Current-Release-Notes.mdx
+++ b/de/s/article/Current-Release-Notes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Aktuelle Versionshinweise"
+excerpt: "Übersicht der aktuellen Version mit dem Drag-and-Drop-Builder für App-Komponenten und schreibgeschützter Cloud-Integration für Azure SQL und MySQL."
 ---
 ## Neue Funktionen und Verbesserungen
 


### PR DESCRIPTION
## Summary
- Adds the `excerpt:` frontmatter field to all 33 German KB articles under `de/s/article/`, bringing the German corpus into compliance with the convention added in #224.
- Each excerpt is a single German sentence (under ~150 characters) summarizing what the article covers. Domo product/feature names (DataSet, Beast Mode, Magic ETL, etc.) are kept in their English form per house convention.
- Companion to #225 (English), #226 (Japanese), #227 (French), and #228 (Spanish). Final language PR in the backfill series.

## Review notes
- Diff: 33 single-line additions, one new `excerpt:` line per file under `title:`. No other content was modified.
- The `excerpt:` field is repo-only metadata; Mintlify does not render it on the published page.

## Test plan
- [x] Spot-check ~5 random German articles for excerpt accuracy and natural German phrasing.
- [x] Confirm Mintlify preview renders normally with no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)