### PR TITLE
Bring AI Library article into style-guide compliance

### DIFF
--- a/s/article/AI-Library.mdx
+++ b/s/article/AI-Library.mdx
@@ -1,87 +1,95 @@
 ---
 title: AI Library
+tag: "Beta"
 excerpt: "Use the Domo AI Library to curate AI solutions, build custom agents with AI Agent Builder, and assemble Toolkits that govern agent capabilities."
 ---
 
-<Frame><img alt="beta.png" src="/images/kb/beta.png" style={{width: 36, height: 24}}/></Frame>
+<Note>
+  **Note:** This feature is in beta. Beta Program participants can enable
+  features [here](https://embed.domo.com/embed/pages/DQ8Ek). To join the Beta
+  Program, fill out [this form](https://embed.domo.com/embed/pages/K8GMx). For beta questions or feedback, email
+  [beta.admin@domo.com](mailto:beta.admin@domo.com).
+</Note>
 
-Domo's AI and Data Products Platform provides a centralized environment for building and managing AI agents that operate with trusted, governed business data. The Domo AI Library is a central hub for curating and managing AI solutions.
+## Intro
 
-Within the AI Library, users can leverage AI Agent Builder to create custom agents or agentic workflows tailored to specific use cases.
+This article explains how to use the AI Library to create Toolkits, build custom Agents with AI Agent Builder, and configure Agents for use across the Domo platform.
 
+---
 
 ## Required Grants
 
-The following grants allow you to use the AI Library feature.
-* **Use AI Services** - Access to features and Apps built using the AI Services Layer.
-* **Use AI Chat** - Access to the Domo AI Assistant.
-* **Manage Conversational Agents** - View, edit and delete any Conversational Agent feature in this instance.
-* **Manage Toolkits** - View, edit and delete any Toolkit feature in this instance.
+To access the AI Library, the following grants must be enabled for your role:
 
-Learn about [grants and custom roles](https://domo-support.domo.com/s/article/360043438973?language=en_US).
+- **Use AI Services —** Access to features and Apps built using the AI Services Layer.
+- **Use AI Chat —** Access to the Domo AI Assistant.
+- **Manage Conversational Agents —** View, edit, and delete any Conversational Agent feature in this instance.
+- **Manage Toolkits —** View, edit, and delete any Toolkit feature in this instance.
 
-## Accessing the AI Library
+Learn more about [grants](/s/article/360043438973).
 
-AI Library can be found under the **AI and Machine Learning** navigation section.
+## Access the AI Library
 
-<Frame><img alt="ai_library_ai_library_nav.png" src="/images/kb/ai_library_ai_library_nav.png" style={{width: 416, height: 482}}/></Frame>
+The AI Library can be found under the **AI and Machine Learning** navigation section.
 
-To power agents, teams can create AI Toolkits — packaged sets of capabilities that define what an agent can do. Toolkits allow users to combine tools, data, and workflows with the instructions and business context that guide how an agent operates. These reusable packages can include operational logic and domain-specific knowledge, enabling agents to take on roles such as a financial analyst or operations manager.
+<Frame><img alt="AI Library navigation" src="/images/kb/ai_library_ai_library_nav.png" /></Frame>
 
-Toolkits may be created by customers, provided by Domo for common use cases, or connected to external services. Assigning toolkits to agents allows organizations to control the actions and systems those agents can access. Toolkits can also be exposed externally through MCP, allowing AI assistants such as Gemini or Claude to access those capabilities through the Domo MCP Server.
+To power agents, teams can create AI Toolkits—packaged sets of capabilities that define what an agent can do. Toolkits allow users to combine tools, data, and workflows with the instructions and business context that guide how an agent operates. These reusable packages can include operational logic and domain-specific knowledge, enabling agents to take on roles such as a financial analyst or operations manager.
 
-<Frame><img alt="ai_library_ai_library.png" src="/images/kb/ai_library_ai_library.png" style={{width: 624, height: 466}}/></Frame>
+Toolkits may be created by customers, provided by Domo for common use cases, or connected to external services. Assigning Toolkits to agents allows organizations to control the actions and systems those agents can access. Toolkits can also be exposed externally through MCP, allowing AI assistants such as Gemini or Claude to access those capabilities through the Domo MCP Server.
 
-## Creating a Toolkit
+<Frame><img alt="AI Library overview" src="/images/kb/ai_library_ai_library.png" /></Frame>
+
+## Create a Toolkit
 
 The following steps walk through creating a Toolkit to support a **User Management** Agent.
 
 1. From the **New Asset** menu, choose **Toolkit**.
 
-   <Frame><img alt="ai_library_create_tool.png" src="/images/kb/ai_library_create_tool.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="New Asset menu with Toolkit option" src="/images/kb/ai_library_create_tool.png" /></Frame>
 
 2. Give the Toolkit a name and description. For this example, enter **User Management** as the name and **Tools to help manage Users** as the description.
 
-   <Frame><img alt="ai_library_create_tool_1.png" src="/images/kb/ai_library_create_tool_1.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Toolkit name and description" src="/images/kb/ai_library_create_tool_1.png" /></Frame>
 
 3. Under the **Add Tools** menu, choose between Domo-provided tools, Workflows, or Code Engine functions. Choosing **Domo Tools** or **Workflows** lists all Workflows you have access to.
 
-   <Frame><img alt="ai_library_create_tool_2.png" src="/images/kb/ai_library_create_tool_2.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Add Tools menu" src="/images/kb/ai_library_create_tool_2.png" /></Frame>
 
-   <Frame><img alt="ai_library_create_tool_4.png" src="/images/kb/ai_library_create_tool_4.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Workflows tool selection" src="/images/kb/ai_library_create_tool_4.png" /></Frame>
 
 4. Choose **Code Engine** and search for the **DOMO User's** package.
 
-   <Frame><img alt="ai_library_create_tool_5.png" src="/images/kb/ai_library_create_tool_5.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Code Engine package search" src="/images/kb/ai_library_create_tool_5.png" /></Frame>
 
 5. From the DOMO User's package, select the **createUser**, **updateUserRole**, and **fetchUser** functions.
 
-   <Frame><img alt="ai_library_create_tool_6.png" src="/images/kb/ai_library_create_tool_6.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="createUser function" src="/images/kb/ai_library_create_tool_6.png" /></Frame>
 
-   <Frame><img alt="ai_library_create_tool_7.png" src="/images/kb/ai_library_create_tool_7.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="updateUserRole function" src="/images/kb/ai_library_create_tool_7.png" /></Frame>
 
-   <Frame><img alt="ai_library_create_tool_8.png" src="/images/kb/ai_library_create_tool_8.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="fetchUser function" src="/images/kb/ai_library_create_tool_8.png" /></Frame>
 
 6. Save the Toolkit.
 
-   <Frame><img alt="ai_library_create_tool_9.png" src="/images/kb/ai_library_create_tool_9.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Saved Toolkit" src="/images/kb/ai_library_create_tool_9.png" /></Frame>
 
-## Managing Toolkits
+## Manage Toolkits
 
 From the Toolkit menu, you can perform the following actions:
 
-<Frame><img alt="ai_library_create_tool_10.png" src="/images/kb/ai_library_create_tool_10.png" style={{width: 624, height: 466}}/></Frame>
+<Frame><img alt="Toolkit actions menu" src="/images/kb/ai_library_create_tool_10.png" /></Frame>
 
-- **Edit** — Edit an existing Toolkit.
+- **Edit —** Edit an existing Toolkit.
 
-  <Frame><img alt="ai_library_create_tool_11.png" src="/images/kb/ai_library_create_tool_11.png" style={{width: 298, height: 184}}/></Frame>
+  <Frame><img alt="Edit Toolkit dialog" src="/images/kb/ai_library_create_tool_11.png" /></Frame>
 
-- **Use in MCP** — View the connection details for this Toolkit.
-- **Delete** — Remove this Toolkit from the library.
+- **Use in MCP —** View the connection details for this Toolkit.
+- **Delete —** Remove this Toolkit from the library.
 
-  <Frame><img alt="ai_library_delete.png" src="/images/kb/ai_library_delete.png" style={{width: 342, height: 102}}/></Frame>
+  <Frame><img alt="Delete Toolkit confirmation" src="/images/kb/ai_library_delete.png" /></Frame>
 
-## Creating an Agent
+## Create an Agent
 
 Agents built with these tools can be deployed across multiple experiences, including customizable AI chat interfaces embedded into dashboards, applications, and workflows across the Domo platform.
 
@@ -89,80 +97,80 @@ The following steps walk through creating the **User Management** Agent that use
 
 1. From the **New Asset** menu, choose **Agent**.
 
-   <Frame><img alt="ai_library_new_agent_1.png" src="/images/kb/ai_library_new_agent_1.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="New Asset menu with Agent option" src="/images/kb/ai_library_new_agent_1.png" /></Frame>
 
-2. Give the Agent a name — for this example, **User Management**. On the first screen, choose a model, configure the output structure, provide instructions, and define the prompt the Agent will use.
+2. Give the Agent a name—for this example, **User Management**. On the first screen, choose a model, configure the output structure, provide instructions, and define the prompt the Agent will use.
 
-   <Frame><img alt="ai_library_new_agent_2.png" src="/images/kb/ai_library_new_agent_2.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent model selection" src="/images/kb/ai_library_new_agent_2.png" /></Frame>
 
-   <Frame><img alt="ai_library_new_agent_3.png" src="/images/kb/ai_library_new_agent_3.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent output structure" src="/images/kb/ai_library_new_agent_3.png" /></Frame>
 
-   <Frame><img alt="ai_library_new_agent_4.png" src="/images/kb/ai_library_new_agent_4.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent instructions and prompt" src="/images/kb/ai_library_new_agent_4.png" /></Frame>
 
 3. On the second screen, add Toolkits and control the interactions between the user and the tools.
 
-   <Frame><img alt="ai_library_new_agent_5.png" src="/images/kb/ai_library_new_agent_5.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent Toolkit configuration" src="/images/kb/ai_library_new_agent_5.png" /></Frame>
 
 4. On the third screen, add Knowledge or Context to the Agent. Choose **Datasources** (structured data) or **Documents** (unstructured data).
 
-   <Frame><img alt="ai_library_new_agent_6.png" src="/images/kb/ai_library_new_agent_6.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent Knowledge and Context" src="/images/kb/ai_library_new_agent_6.png" /></Frame>
 
 5. On the fourth screen, define the user experience, including welcome messages and other display options.
 
-   <Frame><img alt="ai_library_new_agent_7.png" src="/images/kb/ai_library_new_agent_7.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent user experience settings" src="/images/kb/ai_library_new_agent_7.png" /></Frame>
 
 6. On the final screen, define the theme.
 
-   <Frame><img alt="ai_library_new_agent_8.png" src="/images/kb/ai_library_new_agent_8.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent theme settings" src="/images/kb/ai_library_new_agent_8.png" /></Frame>
 
-   <Frame><img alt="ai_library_new_agent_9.png" src="/images/kb/ai_library_new_agent_9.png" style={{width: 624, height: 466}}/></Frame>
+   <Frame><img alt="Agent theme preview" src="/images/kb/ai_library_new_agent_9.png" /></Frame>
 
-## Managing Agents
+## Manage Agents
 
 From the Agent menu, you can perform the following actions:
 
-<Frame><img alt="ai_library_new_agent_menu.png" src="/images/kb/ai_library_new_agent_menu.png" style={{width: 624, height: 466}}/></Frame>
+<Frame><img alt="Agent actions menu" src="/images/kb/ai_library_new_agent_menu.png" /></Frame>
 
-- **View Details** — See an overview of the Agent and the tools it uses.
-- **Edit** — Edit an existing Agent.
-- **Embed** — Enable embedding for this Agent.
+- **View Details —** See an overview of the Agent and the tools it uses.
+- **Edit —** Edit an existing Agent.
+- **Embed —** Enable embedding for this Agent.
 
-  <Frame><img alt="ai_library_agent_embed.png" src="/images/kb/ai_library_agent_embed.png" style={{width: 432, height: 211}}/></Frame>
+  <Frame><img alt="Agent embed settings" src="/images/kb/ai_library_agent_embed.png" /></Frame>
 
-- **Share** — Share this Agent with others in your company.
+- **Share —** Share this Agent with others in your company.
 
-  <Frame><img alt="ai_library_agent_share.png" src="/images/kb/ai_library_agent_share.png" style={{width: 319, height: 326}}/></Frame>
+  <Frame><img alt="Agent share dialog" src="/images/kb/ai_library_agent_share.png" /></Frame>
 
-- **Delete** — Remove this Agent from the library.
+- **Delete —** Remove this Agent from the library.
 
-  <Frame><img alt="ai_library_delete.png" src="/images/kb/ai_library_delete.png" style={{width: 342, height: 102}}/></Frame>
+  <Frame><img alt="Delete Agent confirmation" src="/images/kb/ai_library_delete.png" /></Frame>
 
-## Configuring an Agent
+## Configure an Agent
 
-Navigate to the **AI Service Layer Settings** under the **AI Service Layer** section in Admin settings. Choose your Agent from the **Global Chat Agents** menu.
+Navigate to the **AI Service Layer Settings** under the **AI Service Layer** section in the Admin Settings. Choose your Agent from the **Global Chat Agents** menu.
 
-<Frame><img alt="ai_library_chat_settings.png" src="/images/kb/ai_library_chat_settings.png" style={{width: 624, height: 466}}/></Frame>
+<Frame><img alt="AI Service Layer chat settings" src="/images/kb/ai_library_chat_settings.png" /></Frame>
 
-## Using an Agent
+## Use an Agent
 
 1. Choose **AI Chat** from the main navigation.
 
-   <Frame><img alt="ai_library_chat_nav.png" src="/images/kb/ai_library_chat_nav.png" style={{width: 416, height: 482}}/></Frame>
+   <Frame><img alt="AI Chat navigation" src="/images/kb/ai_library_chat_nav.png" /></Frame>
 
 2. Your Agent is now active. In the input field, enter a request. To create a new user, provide a display name, email address, and role. For example:
 
    *"Create a new user; Joe Schmoe, bikeb4work@gmail.com, Admin"*
 
-   <Frame><img alt="ai_library_new_chat.png" src="/images/kb/ai_library_new_chat.png" style={{width: 307, height: 409}}/></Frame>
+   <Frame><img alt="AI Chat new user request" src="/images/kb/ai_library_new_chat.png" /></Frame>
 
-   <Frame><img alt="ai_library_user_created_1.png" src="/images/kb/ai_library_user_created_1.png" style={{width: 307, height: 409}}/></Frame>
+   <Frame><img alt="AI Chat user created response" src="/images/kb/ai_library_user_created_1.png" /></Frame>
 
 3. Navigate to **Admin** > **People** to confirm the new user was provisioned.
 
-   <Frame><img alt="ai_library_user_created_2.png" src="/images/kb/ai_library_user_created_2.png" style={{width: 624, height: 96}}/></Frame>
+   <Frame><img alt="People page showing new user" src="/images/kb/ai_library_user_created_2.png" /></Frame>
 
 4. To use a second tool in the Toolkit, try updating the user's role. For example:
 
    *"Change Joe Schmoe's (416551720) role from Admin to Privileged"*
 
-   <Frame><img alt="ai_library_user_role_change.png" src="/images/kb/ai_library_user_role_change.png" style={{width: 624, height: 286}}/></Frame>
+   <Frame><img alt="AI Chat role change response" src="/images/kb/ai_library_user_role_change.png" /></Frame>


### PR DESCRIPTION
## Summary
- Replace the legacy `beta.png` image marker with the whole-article beta convention: `tag: "Beta"` in frontmatter plus the standard beta Note immediately after frontmatter.
- Apply style-guide fixes throughout: `## Intro` heading with imperative "This article explains..." lead and horizontal rule, Required Grants lead-in sentence with `-` bullets and em-dash-inside-bold formatting, internal grants link, imperative-mood headings (Access/Create/Manage/Configure/Use), removed Frame `<img>` width/height styles, descriptive alt text, and em-dash spacing corrections in prose and description lists.

## Test plan
- [x] Verify the rendered article shows the Beta sidebar badge and the standard beta Note above the Intro.
- [x] Confirm all screenshots render at proper widths now that explicit Frame img sizes are removed.
- [x] Spot-check headings render in imperative mood and Required Grants formatting matches the style guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)