### PR TITLE
chore: gitignore Asana backlog scratch dirs under tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,10 @@ test-results/
 # -----------------------------------------------------------------------------
 .asana-cache/
 
+# Asana backlog scratch (regenerable from .asana-cache; tmp/ otherwise holds tracked working files)
+tmp/cgh_media/
+tmp/ticket_bundles/
+
 # -----------------------------------------------------------------------------
 # Misc
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds two targeted `.gitignore` entries:

```
tmp/cgh_media/
tmp/ticket_bundles/
```

## Why

The Asana backlog tooling (from `update/asanaBacklog`) wrote scratch files into `tmp/cgh_media/` (media pulled from tickets) and `tmp/ticket_bundles/` (per-ticket note bundles). These leaked into `git status` on `main` because `tmp/` — unlike `temp/` — isn't gitignored.

The files were never committed, aren't tracked on any branch, are regenerable from `.asana-cache/` (itself gitignored), and are referenced by nothing. They've been removed locally; this ignores the two subdirs so they don't reappear in `git status` if the tooling runs again.

Scoped to the two subdirs specifically rather than ignoring all of `tmp/`, because `tmp/` also holds tracked working files (`chart-mapping.mdx`, `deletion-candidates.md`, `inline-icon-mapping.{json,md}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)