### PR TITLE
docs(release): add v2.6.0 release notes

### DIFF
--- a/releaseNotes/v2.6.0.mdx
+++ b/releaseNotes/v2.6.0.mdx
@@ -1,0 +1,75 @@
+---
+title: "Domo Documentation Hub v2.6.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.6.0 of the Domo Documentation Hub is now available! This is a big one — it rolls up everything that landed since v2.5.0, with a major push on AI documentation (admin controls, Magic ETL, agents, and adapters), the general availability of Domo on Snowflake, brand-new overview pages, and a wave of connector updates. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🤖 AI Admin & Governance
+
+Administrators now have dedicated documentation for managing AI across their instance. New articles cover the [AI Admin Settings](https://www.domo.com/docs/s/article/AI-Admin-Settings) page (model selection and instance-wide configuration), [AI Admin Agent Settings](https://www.domo.com/docs/s/article/AI-Admin-Agent-Settings) for governing agent behavior, and [AI Chat DataSet Restrictions](https://www.domo.com/docs/s/article/AI-Chat-DataSet-Restrictions) for controlling which datasets AI Chat can reach via enable/disable and blocklist options.
+
+Thanks to Ken Boyer for authoring these admin-facing guides.
+
+### 🧠 AI Agents, Toolkits & Adapters
+
+The [AI Library](https://www.domo.com/docs/s/article/AI-Library) article was substantially expanded with end-to-end guidance on creating and managing toolkits and agents — including configuring and using an agent. We also added a new [AI Adapters article for Databricks, OpenAI, and Amazon Bedrock](https://www.domo.com/docs/s/article/AI-Adapters-Databricks-OpenAI-Bedrock) so you can bring your own models into Domo.
+
+Thanks to Bryce Cindrich for the agent and toolkit content, and to Jared Peterson for the adapters guide.
+
+### ✨ AI in Magic ETL and Jupyter
+
+Magic ETL gained a dedicated [Magic ETL + AI](https://www.domo.com/docs/s/article/Magic-ETL-AI) overview, and the [Magic ETL Tiles: AI Services](https://www.domo.com/docs/s/article/000005741) article now documents the Text Generation tile alongside the new Classification and Sentiment Analysis tiles (both in beta), each with required grants, configuration steps, and an FAQ. For notebook users, the [Use AI Prompts in Jupyter](https://www.domo.com/docs/s/article/000005544) article now details the optional parameters — prompt templates, model configuration, chunking, and output styling.
+
+Thanks to Ken Boyer for the Magic ETL AI tiles and to Jared Peterson for the Jupyter parameters.
+
+### 🗂️ Content Governance Hub
+
+A brand-new [Content Governance Hub](https://www.domo.com/docs/s/article/Content-Governance-Hub) article walks admins through the hub's architecture, content summary, archiving criteria, and the workflow used to keep instances clean and well-governed.
+
+Thanks to Jared Peterson for authoring this guide.
+
+### ❄️ Domo on Snowflake (General Availability)
+
+The [Domo on Snowflake](https://www.domo.com/docs/s/article/4402322966807) article received a major overhaul for GA, adding full coverage of creating and managing Snowflake integrations, configuring write and native transform, setting up OAuth in both Snowflake and Domo, and a new troubleshooting section.
+
+Thanks to Felipe Suarez for the GA rewrite, with a style pass from Jared Peterson.
+
+### 📚 New Overview Pages & App Tooling
+
+Two new conceptual landing pages help readers get oriented: the [Analyzer Overview](https://www.domo.com/docs/s/article/Analyzer-Overview) and the [DomoStats Overview](https://www.domo.com/docs/s/article/DomoStats-Overview). We also added a developer-focused [Wire an App](https://www.domo.com/docs/s/article/Wire-an-App) article covering manifest setup, dataset alias mapping, and collections, plus a new [Query DataSet Tile](https://www.domo.com/docs/s/article/Query-DataSet-Tile) reference.
+
+Thanks to Jared Peterson for these new pages.
+
+### 📈 DomoStats Connector Expansion
+
+The [DomoStats Connector](https://www.domo.com/docs/s/article/360043433813) article was significantly expanded to document dozens of available DataSets — including new AI-focused reports such as AI Readiness, AI Models, AI Model Endpoints, AI Chat Sessions, and AI Services — so you can report on AI adoption and governance alongside the rest of your instance metadata.
+
+Thanks to Jesse Kreitzman and Ken Boyer for the added DataSet and filter-criteria detail.
+
+### 🎨 Dashboards, Stories & Workflows
+
+Several authoring experiences got richer documentation. [Creating Domo Stories](https://www.domo.com/docs/s/article/360043428433) now covers converting standard dashboards to and from Stories and setting dashboard background colors and images. The [Brand Kit](https://www.domo.com/docs/s/article/5428851518999) article documents removing the footer from your instance, and [Create a Workflow](https://www.domo.com/docs/s/article/000005331) now explains adding comments and connecting existing steps on the canvas.
+
+Thanks to Jared Peterson for these updates.
+
+### 🔌 Connector Updates
+
+A round of connector refreshes added new and updated reports: a Detailed Report (FlexQ) for the [Amazon Selling Partner](https://www.domo.com/docs/s/article/7964629384087) connector, updates to the [Shopify](https://www.domo.com/docs/s/article/360042927994) and [SFTP](https://www.domo.com/docs/s/article/000005408) connectors, a new report for the [Toggl](https://www.domo.com/docs/s/article/360043435033) connector, and updated reports for the [Salesforce Pardot](https://www.domo.com/docs/s/article/1500002456742) connector.
+
+Thanks to Arun Raj for keeping our connector docs current.
+
+### 🛠️ Reference & FAQ Refresh
+
+As part of clearing our documentation backlog, the [Workbench 5.1 FAQs](https://www.domo.com/docs/s/article/4407026671767) article picked up new answers — including whether you can run the Workbench service under a Windows service account while users sign in individually, and whether Workbench can match filenames by "contains" rather than an exact name.
+
+Thanks to Jared Peterson for working through the backlog.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who contributed to this release — this roll-up represents weeks of work across AI, governance, connectors, and the core authoring experience. We're grateful for every article, edit, and review that made it in.
+
+If you have questions or feedback, please reach out — we're always happy to help!


### PR DESCRIPTION
## Summary

Adds the **v2.6.0 release notes** to `releaseNotes/`. Because no notes were written for v2.5.1 or v2.5.2, this is a roll-up covering **all changes from v2.5.0 through v2.6.0**.

## Themes covered

- 🤖 AI Admin & Governance — AI Admin Settings, Agent Settings, Chat DataSet Restrictions
- 🧠 AI Agents, Toolkits & Adapters — AI Library expansion, AI Adapters (Databricks/OpenAI/Bedrock)
- ✨ AI in Magic ETL and Jupyter — Magic ETL + AI, AI Services tiles, Jupyter prompt parameters
- 🗂️ Content Governance Hub
- ❄️ Domo on Snowflake (GA)
- 📚 New overview pages & app tooling — Analyzer Overview, DomoStats Overview, Wire an App, Query DataSet Tile
- 📈 DomoStats Connector expansion
- 🎨 Dashboards, Stories & Workflows — Domo Stories, Brand Kit, Create a Workflow
- 🔌 Connector updates — Amazon Selling Partner, Shopify, SFTP, Toggl, Pardot
- 🛠️ Reference & FAQ refresh — Workbench 5.1 FAQs

Sub-threshold polish (bulk excerpt/formatting passes, localized files, reverted Impersonate Users article, tooling/scripts) is intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)