### PR TITLE
Remove nonexistent 'automated' label from Video Library sync PR

### DIFF
--- a/.github/workflows/sync-video-library.yml
+++ b/.github/workflows/sync-video-library.yml
@@ -81,8 +81,7 @@ jobs:
               --base main \
               --head "$BRANCH" \
               --title "Sync Domo Video Library" \
-              --body "Automated rebuild of the Domo Video Library from the source DataSet. Review the diff (article copy + thumbnails) and merge to publish." \
-              --label "automated"
+              --body "Automated rebuild of the Domo Video Library from the source DataSet. Review the diff (article copy + thumbnails) and merge to publish."
             PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           fi
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The sync-video-library workflow failed at the gh pr create step because it passed --label "automated", a label that doesn't exist in the repo. gh validates labels up front and exits non-zero when one is missing, and the step runs under set -euo pipefail, so the whole job failed (after the branch had already been pushed but before any PR was opened).

The label was only cosmetic (filtering bot PRs), not functional, so drop the flag rather than create/maintain the label.