### PR TITLE
Add external release notes + v2.7.0 notes, update skill base-tag logic

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-notes
-description: Generate user-friendly release notes by diffing the latest git tag against the previous tag and summarizing the changes. Use when the user asks to "generate release notes", "write release notes for the latest release", "summarize the latest release", or similar. Saves a shareable MDX file to `releaseNotes/`.
+description: Generate user-friendly release notes by diffing the latest git tag against the previous tag and summarizing the changes. Use when the user asks to "generate release notes", "write release notes for the latest release", "summarize the latest release", or similar. Saves a shareable MDX file to `releaseNotes/` and a sanitized external version to `releaseNotesExternal/`.
 ---
 
 # Release Notes Generator
@@ -129,12 +129,30 @@ Formatting rules:
 
 Keep tone warm and appreciative.
 
-### 7. Confirm
+### 7. Generate the external version
 
-Tell the user the file path and offer to adjust tone, detail, or framing.
+After saving the internal file, produce a sanitized copy for external audiences (customers, partners, public-facing channels) and save it to `releaseNotesExternal/v<version>.mdx`.
+
+**What to strip or omit:**
+
+- **Contributor attribution** — remove every "Thanks to [Name] for…" sentence. The closing "Thank You" section may be kept but must not name individuals; replace with a generic warm sign-off (e.g., "A heartfelt thank you to everyone who helped make this release possible.").
+- **Internal-only themes** — drop entire `###` sections whose subject matter is not visible to or useful for Domo customers. Examples of internal-only content:
+  - New or updated Claude AI skills, slash commands, or documentation-team workflows
+  - GitHub Actions or CI/CD pipeline changes
+  - Internal scripts, tooling, or developer-experience improvements that don't affect the public docs site
+  - Changes to `CLAUDE.md`, `.claude/`, or other repo-meta files
+- **Everything else stays** — all customer-facing article additions and updates remain, including links.
+
+**Title and intro:** Keep the same version number and framing. The title field does not need to change. Adjust the intro only if it references themes you've dropped.
+
+**File location:** `releaseNotesExternal/v<version>.mdx` — the `Write` tool creates the directory automatically.
+
+### 8. Confirm
+
+Tell the user both file paths and offer to adjust tone, detail, or framing for either version.
 
 ## Notes
 
-- Always create `releaseNotes/` if it doesn't exist — `Write` handles this automatically.
-- Do **not** include internal ticket IDs (DOMO-XXXXXX) in the final notes unless the user asks; parenthetical attribution is fine.
-- Do **not** commit the file unless the user asks.
+- Always create `releaseNotes/` and `releaseNotesExternal/` if they don't exist — `Write` handles this automatically.
+- Do **not** include internal ticket IDs (DOMO-XXXXXX) in either version unless the user asks; parenthetical attribution is fine in the internal version.
+- Do **not** commit either file unless the user asks.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -12,10 +12,21 @@ Produce a friendly, email/Slack-ready release notes summary for the most recent 
 ### 1. Identify the release range
 
 ```bash
-git tag --sort=-creatordate | head -5
+git tag --sort=-creatordate | head -10
 ```
 
-The top tag is the **latest release**; the next tag is the **previous release**. Confirm with the user only if the intended target is ambiguous (e.g. multiple tags on the same day, or user mentions a specific version).
+The top tag is the **latest release**. The **base** for the diff is **not** simply the previous tag — it is the tag that corresponds to the most recent version for which release notes have already been generated.
+
+**Finding the base tag:**
+
+1. List the files already in `releaseNotes/` to see which versions have notes:
+   ```bash
+   ls releaseNotes/
+   ```
+2. The highest version with an existing release notes file is the base. For example, if `releaseNotes/` contains `v2.6.0.mdx` and the tags are `v2.7.0 → v2.6.2 → v2.6.1 → v2.6.0`, the diff range is `v2.6.0..v2.7.0` — spanning all three intervening patch tags.
+3. If every tag already has release notes (i.e., the previous tag is also the base), use the previous tag as normal.
+
+Confirm with the user only if the intended target is ambiguous (e.g. multiple tags on the same day, or the user mentions a specific version).
 
 Also grab tag dates for context:
 

--- a/releaseNotes/v2.7.0.mdx
+++ b/releaseNotes/v2.7.0.mdx
@@ -1,0 +1,52 @@
+---
+title: "Domo Documentation Hub v2.7.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.7.0 of the Domo Documentation Hub is now available! This release brings a brand-new Domo Video Library directory, expanded SCIM group management documentation, a wave of connector credential and authentication improvements, and clarifying FAQ additions for Cloud Integrations and Federated Data. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🎥 Domo Video Library
+
+A new [Domo Video Library](https://www.domo.com/docs/s/article/Domo-Video-Library) article provides a curated, alphabetically organized directory of Domo microlearning videos — making it easy for users to browse and bookmark short instructional content. The article is also wired to an automated sync pipeline that keeps the video list current by pulling directly from a Domo DataSet.
+
+Thanks to Cody Webb for building both the article and the automated sync workflow.
+
+### 🔐 SCIM: Group Member Removal
+
+The [SCIM documentation](https://www.domo.com/docs/s/article/000005241) now fully covers the PATCH /Groups endpoint for member management. The updated article clarifies that omitting the `value` field on a Remove operation removes **all members** from the group, and includes new JSON examples for both removing all members at once and replacing a group's full membership.
+
+Thanks to Jesse Kreitzman for the update.
+
+### 🔌 Connector Documentation Updates
+
+Several connector articles received authentication and configuration improvements:
+
+- **SurveyMonkey**: Both the [SurveyMonkey Connector](https://www.domo.com/docs/s/article/360042930774) and [SurveyMonkey Advanced Connector](https://www.domo.com/docs/s/article/360042930754) now document the new **Enterprise OAuth** authentication option, including regional endpoint selection (US, Canada, Europe) and Client ID/Client Secret setup. The Advanced connector also adds two new Details Pane options: Include Custom Variables and Skip Failing Surveys.
+- **Writeback Connectors**: Credentials sections across eight writeback connectors — Box, MySQL, Microsoft SQL Server (both variants), Google BigQuery, Salesforce, Snowflake, PostgreSQL, and Amazon S3 — were updated to link directly to the Domo Client ID and Secret guide, replacing the old inline setup steps.
+- **CSV SFTP Advanced Security**: A new Enable Case-Sensitivity option is now documented in the [CSV SFTP Advanced Security Connector](https://www.domo.com/docs/s/article/360058713713) article, allowing users to match filenames exactly by case when filtering.
+
+Thanks to Arun Raj for the connector documentation work.
+
+### ☁️ Cloud Integrations & Federated Data
+
+Two FAQ additions help users understand caching and DataSet display behavior:
+
+- The [Cloud Integrations Overview](https://www.domo.com/docs/s/article/4412849158167) now explains why a Cloud Integrations DataSet backed by a database View does not display a row count or last updated date — this is expected behavior, as external cloud databases do not expose that metadata for Views.
+- The [Manage Your Federated Data Connection](https://www.domo.com/docs/s/article/360042932974) article now includes a note that queries using dynamic SQL functions like `NOW()`, `CURRENT_DATE()`, or `CURRENT_TIMESTAMP()` generate a new cache key on every load, effectively bypassing caching — with guidance to use Beast Mode date filters instead when cache efficiency matters.
+
+Thanks to Felipe Suarez for the caching and FAQ additions, and to Jared Peterson for the formatting pass.
+
+### 📝 Style Guide & Internal Tooling
+
+The Domo-KB-Style-Guide was updated to document the team's convention for rendering third-party brand logos — using Font Awesome brands glyphs via `<Icon iconType="brands">` where available and inline `<svg fill="currentColor">` paths for brands not in the free FA set (e.g., Anthropic). The Getting Started with AI Agents article was updated to apply the new convention. The Connector Dev Studio was also renamed from "Connector IDE" in the Building Custom Connectors article, which now links directly to the three paths for bringing data into Domo. Minor App Framework FAQ link corrections round out the release.
+
+Thanks to Jared Peterson for the style guide work, Jonathan Tiritilli for the platform fixes, and Arun Raj for the Connector Dev Studio update.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who contributed to this release — Cody Webb, Jesse Kreitzman, Arun Raj, Felipe Suarez, Jared Peterson, Jonathan Tiritilli, and Ken Boyer. Each of you helped make the docs a little clearer and more useful for Domo users everywhere.
+
+If you have questions or feedback, please reach out — we're always happy to help!

--- a/releaseNotesExternal/v2.6.0.mdx
+++ b/releaseNotesExternal/v2.6.0.mdx
@@ -1,0 +1,55 @@
+---
+title: "Domo Documentation Hub v2.6.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.6.0 of the Domo Documentation Hub is now available! This is a big one — it rolls up everything that landed since v2.5.0, with a major push on AI documentation (admin controls, Magic ETL, agents, and adapters), the general availability of Domo on Snowflake, brand-new overview pages, and a wave of connector updates. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🤖 AI Admin & Governance
+
+Administrators now have dedicated documentation for managing AI across their instance. New articles cover the [AI Admin Settings](https://www.domo.com/docs/s/article/AI-Admin-Settings) page (model selection and instance-wide configuration), [AI Admin Agent Settings](https://www.domo.com/docs/s/article/AI-Admin-Agent-Settings) for governing agent behavior, and [AI Chat DataSet Restrictions](https://www.domo.com/docs/s/article/AI-Chat-DataSet-Restrictions) for controlling which datasets AI Chat can reach via enable/disable and blocklist options.
+
+### 🧠 AI Agents, Toolkits & Adapters
+
+The [AI Library](https://www.domo.com/docs/s/article/AI-Library) article was substantially expanded with end-to-end guidance on creating and managing toolkits and agents — including configuring and using an agent. We also added a new [AI Adapters article for Databricks, OpenAI, and Amazon Bedrock](https://www.domo.com/docs/s/article/AI-Adapters-Databricks-OpenAI-Bedrock) so you can bring your own models into Domo.
+
+### ✨ AI in Magic ETL and Jupyter
+
+Magic ETL gained a dedicated [Magic ETL + AI](https://www.domo.com/docs/s/article/Magic-ETL-AI) overview, and the [Magic ETL Tiles: AI Services](https://www.domo.com/docs/s/article/000005741) article now documents the Text Generation tile alongside the new Classification and Sentiment Analysis tiles (both in beta), each with required grants, configuration steps, and an FAQ. For notebook users, the [Use AI Prompts in Jupyter](https://www.domo.com/docs/s/article/000005544) article now details the optional parameters — prompt templates, model configuration, chunking, and output styling.
+
+### 🗂️ Content Governance Hub
+
+A brand-new [Content Governance Hub](https://www.domo.com/docs/s/article/Content-Governance-Hub) article walks admins through the hub's architecture, content summary, archiving criteria, and the workflow used to keep instances clean and well-governed.
+
+### ❄️ Domo on Snowflake (General Availability)
+
+The [Domo on Snowflake](https://www.domo.com/docs/s/article/4402322966807) article received a major overhaul for GA, adding full coverage of creating and managing Snowflake integrations, configuring write and native transform, setting up OAuth in both Snowflake and Domo, and a new troubleshooting section.
+
+### 📚 New Overview Pages & App Tooling
+
+Two new conceptual landing pages help readers get oriented: the [Analyzer Overview](https://www.domo.com/docs/s/article/Analyzer-Overview) and the [DomoStats Overview](https://www.domo.com/docs/s/article/DomoStats-Overview). We also added a developer-focused [Wire an App](https://www.domo.com/docs/s/article/Wire-an-App) article covering manifest setup, dataset alias mapping, and collections, plus a new [Query DataSet Tile](https://www.domo.com/docs/s/article/Query-DataSet-Tile) reference.
+
+### 📈 DomoStats Connector Expansion
+
+The [DomoStats Connector](https://www.domo.com/docs/s/article/360043433813) article was significantly expanded to document dozens of available DataSets — including new AI-focused reports such as AI Readiness, AI Models, AI Model Endpoints, AI Chat Sessions, and AI Services — so you can report on AI adoption and governance alongside the rest of your instance metadata.
+
+### 🎨 Dashboards, Stories & Workflows
+
+Several authoring experiences got richer documentation. [Creating Domo Stories](https://www.domo.com/docs/s/article/360043428433) now covers converting standard dashboards to and from Stories and setting dashboard background colors and images. The [Brand Kit](https://www.domo.com/docs/s/article/5428851518999) article documents removing the footer from your instance, and [Create a Workflow](https://www.domo.com/docs/s/article/000005331) now explains adding comments and connecting existing steps on the canvas.
+
+### 🔌 Connector Updates
+
+A round of connector refreshes added new and updated reports: a Detailed Report (FlexQ) for the [Amazon Selling Partner](https://www.domo.com/docs/s/article/7964629384087) connector, updates to the [Shopify](https://www.domo.com/docs/s/article/360042927994) and [SFTP](https://www.domo.com/docs/s/article/000005408) connectors, a new report for the [Toggl](https://www.domo.com/docs/s/article/360043435033) connector, and updated reports for the [Salesforce Pardot](https://www.domo.com/docs/s/article/1500002456742) connector.
+
+### 🛠️ Reference & FAQ Refresh
+
+As part of clearing our documentation backlog, the [Workbench 5.1 FAQs](https://www.domo.com/docs/s/article/4407026671767) article picked up new answers — including whether you can run the Workbench service under a Windows service account while users sign in individually, and whether Workbench can match filenames by "contains" rather than an exact name.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who helped make this release possible. This roll-up represents weeks of work across AI, governance, connectors, and the core authoring experience.
+
+If you have questions or feedback, please reach out — we're always happy to help!

--- a/releaseNotesExternal/v2.7.0.mdx
+++ b/releaseNotesExternal/v2.7.0.mdx
@@ -1,0 +1,38 @@
+---
+title: "Domo Documentation Hub v2.7.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.7.0 of the Domo Documentation Hub is now available! This release brings a brand-new Domo Video Library directory, expanded SCIM group management documentation, a wave of connector credential and authentication improvements, and clarifying FAQ additions for Cloud Integrations and Federated Data. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🎥 Domo Video Library
+
+A new [Domo Video Library](https://www.domo.com/docs/s/article/Domo-Video-Library) article provides a curated, alphabetically organized directory of Domo microlearning videos — making it easy for users to browse and bookmark short instructional content.
+
+### 🔐 SCIM: Group Member Removal
+
+The [SCIM documentation](https://www.domo.com/docs/s/article/000005241) now fully covers the PATCH /Groups endpoint for member management. The updated article clarifies that omitting the `value` field on a Remove operation removes **all members** from the group, and includes new JSON examples for both removing all members at once and replacing a group's full membership.
+
+### 🔌 Connector Documentation Updates
+
+Several connector articles received authentication and configuration improvements:
+
+- **SurveyMonkey**: Both the [SurveyMonkey Connector](https://www.domo.com/docs/s/article/360042930774) and [SurveyMonkey Advanced Connector](https://www.domo.com/docs/s/article/360042930754) now document the new **Enterprise OAuth** authentication option, including regional endpoint selection (US, Canada, Europe) and Client ID/Client Secret setup. The Advanced connector also adds two new Details Pane options: Include Custom Variables and Skip Failing Surveys.
+- **Writeback Connectors**: Credentials sections across eight writeback connectors — Box, MySQL, Microsoft SQL Server (both variants), Google BigQuery, Salesforce, Snowflake, PostgreSQL, and Amazon S3 — were updated to link directly to the Domo Client ID and Secret guide, replacing the old inline setup steps.
+- **CSV SFTP Advanced Security**: A new Enable Case-Sensitivity option is now documented in the [CSV SFTP Advanced Security Connector](https://www.domo.com/docs/s/article/360058713713) article, allowing users to match filenames exactly by case when filtering.
+
+### ☁️ Cloud Integrations & Federated Data
+
+Two FAQ additions help users understand caching and DataSet display behavior:
+
+- The [Cloud Integrations Overview](https://www.domo.com/docs/s/article/4412849158167) now explains why a Cloud Integrations DataSet backed by a database View does not display a row count or last updated date — this is expected behavior, as external cloud databases do not expose that metadata for Views.
+- The [Manage Your Federated Data Connection](https://www.domo.com/docs/s/article/360042932974) article now includes a note that queries using dynamic SQL functions like `NOW()`, `CURRENT_DATE()`, or `CURRENT_TIMESTAMP()` generate a new cache key on every load, effectively bypassing caching — with guidance to use Beast Mode date filters instead when cache efficiency matters.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who helped make this release possible. Each contributor helped make the docs a little clearer and more useful for Domo users everywhere.
+
+If you have questions or feedback, please reach out — we're always happy to help!


### PR DESCRIPTION
## Summary

- Adds `releaseNotesExternal/` directory and updates the `release-notes` skill to generate a sanitized external version (no contributor names, no internal-only sections) alongside the internal file
- Generates internal and external release notes for v2.7.0, covering all changes since v2.6.0 (spanning v2.6.1 and v2.6.2)
- Updates the `release-notes` skill so the diff base is always the last version with an existing `releaseNotes/` file, not simply the previous git tag — handles the common case where patch releases ship between generated notes

## Test plan

- [x] Review `releaseNotes/v2.7.0.mdx` for accuracy and tone
- [x] Review `releaseNotesExternal/v2.7.0.mdx` and confirm no contributor names or internal-only sections remain
- [x] Check `.claude/skills/release-notes/SKILL.md` Step 1 for the updated base-tag logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)