### PR TITLE
docs: add v2.8.0 release notes

### DIFF
--- a/releaseNotes/v2.8.0.mdx
+++ b/releaseNotes/v2.8.0.mdx
@@ -1,0 +1,45 @@
+---
+title: "Domo Documentation Hub v2.8.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.8.0 of the Domo Documentation Hub is now available! This release adds a wave of new connector guides for Domo Documents, new AI and agent documentation, a left navigation migration guide, and a comprehensive overhaul of the Groups article. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 📄 Domo Documents — Connector Setup Guides
+
+Five new KB articles walk through the credentials and authentication steps needed to connect popular data sources to Domo Documents: Amazon S3, Atlassian Confluence, GitHub, Google Drive, and SFTP. Each guide is focused and self-contained so teams can get a connector running without digging through broader documentation. See the new setup guides for the [Amazon S3 Connector](https://www.domo.com/docs/s/article/Amazon-S3-Connector), [Confluence Connector](https://www.domo.com/docs/s/article/Confluence-Connector), [GitHub Connector](https://www.domo.com/docs/s/article/GitHub-Connector), [Google Drive Connector](https://www.domo.com/docs/s/article/Google-Drive-Connector), and [SFTP Connector](https://www.domo.com/docs/s/article/SFTP-Connector).
+
+Thanks to Ken Boyer for authoring all five guides.
+
+### 🤖 AI Integration and Agent Documentation
+
+Two new articles expand coverage of Domo's AI capabilities. The [Anthropic Admin Connector](https://www.domo.com/docs/s/article/Anthropic-Admin-Connector) guide explains how to import organization, usage, cost, and Claude Code analytics data from the Anthropic Admin API into Domo. A new [Configure Agent Role and Instructions](https://www.domo.com/docs/s/article/Configure-Agent-Role-and-Instructions) article clarifies the difference between the Role and Instructions fields when building a Domo agent, helping teams craft more effective agent behaviors.
+
+Thanks to ArunRaj-Domo for the Anthropic Admin Connector article and to Ken Boyer for the agent configuration guide.
+
+### 🧭 Left Navigation Migration Guide
+
+A new article, [Migrate Users to the New Left Navigation](https://www.domo.com/docs/s/article/Migrate-Users-to-the-New-Left-Navigation), gives Domo admins a step-by-step walkthrough for understanding the migration banner and transitioning users to the new left navigation before Domo disables the top navigation. The article covers per-group enablement options, the banner workflow, and what each enablement state means for your instance.
+
+Thanks to Dany Salas for writing and iterating on the article content.
+
+### 👥 Groups Article Overhaul
+
+The [Create and Manage Groups](https://www.domo.com/docs/s/article/360042934294) article has been substantially reworked — renamed from "Create and Manage User Groups," reformatted with accordion sections for easier navigation, updated to use current Domo UI icons, and corrected for accuracy throughout. Cross-references to this article across the Knowledge Base have been updated to match the new title.
+
+Thanks to Bryce Cindrich for driving this thorough cleanup.
+
+### 🔧 Developer Reference Improvements
+
+The [Adrenaline DataFlows](https://www.domo.com/docs/s/article/360063698733) article gains a new FAQ entry listing the supported data types (STRING, LONG, DECIMAL, DOUBLE, DATE, and DATETIME) and removes an outdated recommendation against row-by-row transformations. The Cards API reference now includes a dedicated `CardSummaryForList` schema for list endpoint responses. The API Authentication guide has been updated to replace `httpie` examples with standard `curl` commands and fix several broken internal links.
+
+Thanks to Felipe Suarez for the Adrenaline DataFlows updates, Connor Grieb for the Cards API schema, and Jesse Kreitzman for the authentication documentation fixes.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who contributed to this release — your careful attention to accuracy, clarity, and completeness makes Domo's documentation better for everyone.
+
+If you have questions or feedback, please reach out — we're always happy to help!

--- a/releaseNotesExternal/v2.8.0.mdx
+++ b/releaseNotesExternal/v2.8.0.mdx
@@ -1,0 +1,35 @@
+---
+title: "Domo Documentation Hub v2.8.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.8.0 of the Domo Documentation Hub is now available! This release adds a wave of new connector guides for Domo Documents, new AI and agent documentation, a left navigation migration guide, and a comprehensive overhaul of the Groups article. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 📄 Domo Documents — Connector Setup Guides
+
+Five new KB articles walk through the credentials and authentication steps needed to connect popular data sources to Domo Documents: Amazon S3, Atlassian Confluence, GitHub, Google Drive, and SFTP. Each guide is focused and self-contained so teams can get a connector running without digging through broader documentation. See the new setup guides for the [Amazon S3 Connector](https://www.domo.com/docs/s/article/Amazon-S3-Connector), [Confluence Connector](https://www.domo.com/docs/s/article/Confluence-Connector), [GitHub Connector](https://www.domo.com/docs/s/article/GitHub-Connector), [Google Drive Connector](https://www.domo.com/docs/s/article/Google-Drive-Connector), and [SFTP Connector](https://www.domo.com/docs/s/article/SFTP-Connector).
+
+### 🤖 AI Integration and Agent Documentation
+
+Two new articles expand coverage of Domo's AI capabilities. The [Anthropic Admin Connector](https://www.domo.com/docs/s/article/Anthropic-Admin-Connector) guide explains how to import organization, usage, cost, and Claude Code analytics data from the Anthropic Admin API into Domo. A new [Configure Agent Role and Instructions](https://www.domo.com/docs/s/article/Configure-Agent-Role-and-Instructions) article clarifies the difference between the Role and Instructions fields when building a Domo agent, helping teams craft more effective agent behaviors.
+
+### 🧭 Left Navigation Migration Guide
+
+A new article, [Migrate Users to the New Left Navigation](https://www.domo.com/docs/s/article/Migrate-Users-to-the-New-Left-Navigation), gives Domo admins a step-by-step walkthrough for understanding the migration banner and transitioning users to the new left navigation before Domo disables the top navigation. The article covers per-group enablement options, the banner workflow, and what each enablement state means for your instance.
+
+### 👥 Groups Article Overhaul
+
+The [Create and Manage Groups](https://www.domo.com/docs/s/article/360042934294) article has been substantially reworked — renamed from "Create and Manage User Groups," reformatted with accordion sections for easier navigation, updated to use current Domo UI icons, and corrected for accuracy throughout. Cross-references to this article across the Knowledge Base have been updated to match the new title.
+
+### 🔧 Developer Reference Improvements
+
+The [Adrenaline DataFlows](https://www.domo.com/docs/s/article/360063698733) article gains a new FAQ entry listing the supported data types (STRING, LONG, DECIMAL, DOUBLE, DATE, and DATETIME) and removes an outdated recommendation against row-by-row transformations. The Cards API reference now includes a dedicated `CardSummaryForList` schema for list endpoint responses. The API Authentication guide has been updated to replace `httpie` examples with standard `curl` commands and fix several broken internal links.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who helped make this release possible — your careful attention to accuracy, clarity, and completeness makes Domo's documentation better for everyone.
+
+If you have questions or feedback, please reach out — we're always happy to help!


### PR DESCRIPTION
## Summary

- Adds `releaseNotes/v2.8.0.mdx` — internal version with contributor attribution
- Adds `releaseNotesExternal/v2.8.0.mdx` — external/customer-facing version (attribution stripped)

Covers the `v2.7.0..v2.8.0` range across 5 themes: Domo Documents connector guides, AI & agent documentation, left navigation migration guide, Groups article overhaul, and developer reference improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)