### PR TITLE
Add Sansan Connector article and alphabetize Data Providers nav

### DIFF
--- a/.claude/skills/migrate-html/SKILL.md
+++ b/.claude/skills/migrate-html/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: migrate-html
+user-invocable: true
+description: "migrate an HTML article to a repo-ready MDX KB article: convert HTML to Markdown with pandoc, apply Domo style rules, save to s/article/, and add to docs.json navigation"
+argument-hint: "optional: paste HTML inline, or leave blank to be prompted"
+---
+
+Migrate an HTML article into a repo-ready MDX file in `s/article/` and register it in `docs.json` navigation.
+
+The user has provided: $ARGUMENTS
+
+---
+
+## Step 1: Gather information
+
+Ask the user for the following if not already provided. Collect all three before proceeding — do not start converting until you have them.
+
+1. **HTML source** — the raw HTML to migrate. The user will paste it directly into the chat.
+
+2. **Target filename** — the MDX filename to use (e.g., `000006094`). This becomes `s/article/<filename>.mdx`. If the user doesn't have a number, ask them to check with the KB admin or look at the highest existing number in `s/article/` as a reference.
+
+3. **Navigation placement** — where the article belongs in `docs.json`. Ask:
+   - Is this a connector article, a general KB article, or something else?
+   - For connector articles: the `add-to-nav` skill handles alphabetical placement automatically — no extra input needed.
+   - For other articles: ask which tab, group, and subgroup it belongs in, and where within that group (beginning, end, or after a specific neighboring article).
+
+---
+
+## Step 2: Convert HTML to Markdown with pandoc
+
+Save the HTML to a temp file, then run pandoc:
+
+```bash
+cat > /tmp/migrate-article.html << 'HTMLEOF'
+<paste HTML here>
+HTMLEOF
+pandoc /tmp/migrate-article.html -f html -t markdown --wrap=none -o /tmp/migrate-article.md && cat /tmp/migrate-article.md
+```
+
+Inspect the output. Pandoc will:
+- Convert headings, bold, italic, lists, links, and tables to Markdown
+- Preserve inline HTML it can't express in Markdown
+- Leave CSS class spans like `[text]{.s1}` — these must be stripped in Step 3
+
+---
+
+## Step 3: Read the style guide and template
+
+Read both files in parallel before writing any MDX:
+
+- `Domo-KB-Style-Guide.mdx`
+- `New-Article-Template.mdx`
+
+Key rules to apply (see those files for full detail):
+
+### Frontmatter
+Every article needs at minimum:
+```mdx
+---
+title: "Article Title"
+excerpt: "Single sentence summarizing what the article covers."
+---
+```
+Do not use `description` — it renders on the published page and duplicates the Intro.
+
+### Article structure
+Intro → (optional) Required Grants → (optional) Prerequisites → task sections → (optional) FAQ
+
+A `---` horizontal rule must follow the **Intro** section.
+
+### Headings
+- Structural labels (`Intro`, `Prerequisites`, `FAQ`, etc.) are exempt from imperative mood.
+- All other headings must use imperative mood: "Connect to Your Account", not "Connecting to Your Account".
+- The frontmatter `title` renders as H1. All top-level sections are H2; subsections H3+.
+
+### Links
+- Internal links: root-relative path, no `.mdx` extension — `[Title](/s/article/360042926274)`
+- Strip `domo-support.domo.com` prefixes from internal links: `https://domo-support.domo.com/s/article/360042926274?language=en_US` → `/s/article/360042926274`
+- External links stay as-is; strip `{target="_blank" rel="noopener noreferrer"}` attributes pandoc may leave behind
+
+### Strip pandoc artifacts
+Remove these from the pandoc output:
+- `[text]{.s1}` → `text` (CSS class spans — just unwrap the text)
+- `{target="_blank" rel="noopener noreferrer"}` after links
+- Inline `style=` attributes on elements
+- Blank `&nbsp;` paragraphs
+
+### Tables
+- Use pipe tables. Pad cells with spaces so column pipes align vertically across all rows.
+- Use `<br/>` to separate multiple lines of plain text within a cell. Do not use `<br/>` between callout components.
+- **Nested tables:** write the inner table as inline HTML in the outer pipe table cell. Keep it on one line:
+
+```
+| Outer Col 1 | Outer Col 2                                                                                                                      |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Row 1       | <table><thead><tr><th>Inner Col 1</th><th>Inner Col 2</th></tr></thead><tbody><tr><td>Value</td><td>Value</td></tr></tbody></table> |
+```
+
+- When a cell contains both plain text and a nested table, separate them with `<br/>`.
+- Avoid `<Frame>` inside table cells — use native `<img>` instead.
+
+### Callouts
+```mdx
+<Note>**Note:** Text here.</Note>
+<Warning>**Important:** Text here.</Warning>
+<Tip>**Tip:** Text here.</Tip>
+```
+Always bold the label. Leave a blank line before a callout (except inside table cells).
+
+---
+
+## Step 4: Write the MDX file
+
+Save the formatted content to `s/article/<filename>.mdx`. Do not add comments, explanatory headers, or TODO markers unless the style guide explicitly calls for them (e.g., screenshot TODOs per the screenshot policy).
+
+---
+
+## Step 5: Add to navigation
+
+Invoke the `add-to-nav` skill:
+
+```
+/add-to-nav s/article/<filename> — <description of where it belongs>
+```
+
+For connector articles, describe it as a connector article and name the service — the skill will find the correct alphabetical slot within the right `Data Providers` group automatically (it reads neighboring article titles to confirm exact placement).
+
+---
+
+## Step 6: Verify JSON
+
+After `add-to-nav` makes its edit:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('docs.json', 'utf8')); console.log('docs.json is valid JSON');"
+```
+
+If this fails, show the error and fix it before finishing.
+
+---
+
+## Output
+
+Tell the user:
+- The path of the new article (`s/article/<filename>.mdx`)
+- Where it was inserted in `docs.json` (group name and neighboring entries)
+- That the branch is ready to commit and preview with `mintlify dev`

--- a/docs.json
+++ b/docs.json
@@ -1203,6 +1203,7 @@
                           "s/article/000005931"
                         ]
                       },
+                      "s/article/000006094",
                       {
                         "group": "SAP",
                         "pages": [

--- a/docs.json
+++ b/docs.json
@@ -1134,7 +1134,6 @@
                   {
                     "group": "Data Providers Q-S",
                     "pages": [
-                      "s/article/360043437633",
                       "s/article/360042930734",
                       "s/article/000005254",
                       {
@@ -1176,6 +1175,7 @@
                           "s/article/360042931314"
                         ]
                       },
+                      "s/article/360043437633",
                       {
                         "group": "Sage Intacct",
                         "pages": [

--- a/docs.json
+++ b/docs.json
@@ -27,7 +27,10 @@
     "drilldown": false
   },
   "contextual": {
-    "options": ["copy", "view"]
+    "options": [
+      "copy",
+      "view"
+    ]
   },
   "navigation": {
     "languages": [
@@ -161,11 +164,15 @@
                       },
                       {
                         "group": "Dremio",
-                        "pages": ["s/article/000005139"]
+                        "pages": [
+                          "s/article/000005139"
+                        ]
                       },
                       {
                         "group": "Lakebase",
-                        "pages": ["s/article/Domo-on-Lakebase"]
+                        "pages": [
+                          "s/article/Domo-on-Lakebase"
+                        ]
                       },
                       {
                         "group": "Microsoft Azure",
@@ -191,7 +198,9 @@
                       },
                       {
                         "group": "Lakebase",
-                        "pages": ["s/article/Domo-on-Lakebase"]
+                        "pages": [
+                          "s/article/Domo-on-Lakebase"
+                        ]
                       },
                       {
                         "group": "MySQL",
@@ -242,7 +251,10 @@
                     "pages": [
                       {
                         "group": "Workbench Enterprise",
-                        "pages": ["s/article/000005587", "s/article/000005303"]
+                        "pages": [
+                          "s/article/000005587",
+                          "s/article/000005303"
+                        ]
                       },
                       {
                         "group": "Workbench 5",
@@ -562,6 +574,7 @@
                       "s/article/360043433753",
                       "s/article/360043433773",
                       "s/article/000005766",
+                      "s/article/360042926534",
                       "s/article/000005751",
                       "s/article/360043435633",
                       "s/article/360043432773",
@@ -580,6 +593,7 @@
                       "s/article/360042929214",
                       "s/article/360061648033",
                       "s/article/360043432193",
+                      "s/article/000006013",
                       "s/article/4410615812759",
                       "s/article/360043433193",
                       "s/article/4409676591127",
@@ -603,8 +617,6 @@
                       "s/article/4404766005655",
                       "s/article/360042929234",
                       "s/article/360042926634",
-                      "s/article/360042926534",
-                      "s/article/000006013",
                       {
                         "group": "Cvent",
                         "pages": [
@@ -887,9 +899,9 @@
                     "pages": [
                       "s/article/360058708833",
                       "s/article/360058892493",
+                      "s/article/4409512475927",
                       "s/article/6643231704471",
                       "s/article/000005759",
-                      "s/article/4409512475927",
                       {
                         "group": "LinkedIn",
                         "pages": [
@@ -1122,6 +1134,7 @@
                   {
                     "group": "Data Providers Q-S",
                     "pages": [
+                      "s/article/360043437633",
                       "s/article/360042930734",
                       "s/article/000005254",
                       {
@@ -1175,7 +1188,6 @@
                           "s/article/360043432313"
                         ]
                       },
-                      "s/article/360043437633",
                       {
                         "group": "Salesforce",
                         "pages": [
@@ -1336,7 +1348,6 @@
                       "s/article/360042930494",
                       "s/article/360043434353",
                       "s/article/360043432053",
-                      "s/article/Wasabi-Connector",
                       {
                         "group": "TikTok",
                         "pages": [
@@ -1395,6 +1406,8 @@
                           "s/article/360042930654"
                         ]
                       },
+                      "s/article/Wasabi-Connector",
+                      "s/article/360042930294",
                       {
                         "group": "Workday",
                         "pages": [
@@ -1417,7 +1430,6 @@
                           "s/article/360042927514"
                         ]
                       },
-                      "s/article/360042930294",
                       {
                         "group": "Xero",
                         "pages": [
@@ -1599,7 +1611,9 @@
                           },
                           {
                             "group": "Magic ETL on Databricks",
-                            "pages": ["s/article/Query-DataSet-Tile"]
+                            "pages": [
+                              "s/article/Query-DataSet-Tile"
+                            ]
                           },
                           {
                             "group": "Legacy Magic ETL",
@@ -1648,7 +1662,9 @@
                       },
                       {
                         "group": "Enterprise Stacker",
-                        "pages": ["s/article/360042923754"]
+                        "pages": [
+                          "s/article/360042923754"
+                        ]
                       }
                     ]
                   },
@@ -2027,7 +2043,9 @@
                   },
                   {
                     "group": "Worksheets",
-                    "pages": ["s/article/Use-Worksheets"]
+                    "pages": [
+                      "s/article/Use-Worksheets"
+                    ]
                   }
                 ]
               },
@@ -2286,7 +2304,10 @@
                       "s/article/000005510",
                       {
                         "group": "Credit Consumption",
-                        "pages": ["s/article/000005492", "s/article/000005280"]
+                        "pages": [
+                          "s/article/000005492",
+                          "s/article/000005280"
+                        ]
                       },
                       {
                         "group": "Governance",
@@ -2475,7 +2496,10 @@
                       },
                       {
                         "group": "Publish on the Appstore",
-                        "pages": ["s/article/000005184", "s/article/000005183"]
+                        "pages": [
+                          "s/article/000005184",
+                          "s/article/000005183"
+                        ]
                       },
                       {
                         "group": "Available Apps",
@@ -3550,7 +3574,10 @@
               },
               {
                 "group": "Domo SDK",
-                "pages": ["s/article/360042936554", "s/article/360042923734"]
+                "pages": [
+                  "s/article/360042936554",
+                  "s/article/360042923734"
+                ]
               }
             ]
           },
@@ -3870,7 +3897,9 @@
                       },
                       {
                         "group": "Dremio",
-                        "pages": ["ja/s/article/000005139"]
+                        "pages": [
+                          "ja/s/article/000005139"
+                        ]
                       },
                       {
                         "group": "Microsoft Azure",
@@ -4580,7 +4609,9 @@
                       },
                       {
                         "group": "Sage Intacct",
-                        "pages": ["ja/s/article/000005099"]
+                        "pages": [
+                          "ja/s/article/000005099"
+                        ]
                       },
                       "ja/s/article/360043437633",
                       {
@@ -4700,7 +4731,9 @@
                       },
                       {
                         "group": "USGS",
-                        "pages": ["ja/s/article/360043432433"]
+                        "pages": [
+                          "ja/s/article/360043432433"
+                        ]
                       },
                       "ja/s/article/360042928054",
                       {
@@ -4886,7 +4919,9 @@
                           },
                           {
                             "group": "Databricks上のMagic ETL",
-                            "pages": ["ja/s/article/Query-DataSet-Tile"]
+                            "pages": [
+                              "ja/s/article/Query-DataSet-Tile"
+                            ]
                           },
                           {
                             "group": "レガシーMagic ETL",
@@ -4935,7 +4970,9 @@
                       },
                       {
                         "group": "Enterprise Stacker",
-                        "pages": ["ja/s/article/360042923754"]
+                        "pages": [
+                          "ja/s/article/360042923754"
+                        ]
                       }
                     ]
                   },
@@ -5363,7 +5400,9 @@
                   },
                   {
                     "group": "スケジュールレポート",
-                    "pages": ["ja/s/article/360043437773"]
+                    "pages": [
+                      "ja/s/article/360043437773"
+                    ]
                   },
                   {
                     "group": "アラート",
@@ -5829,7 +5868,9 @@
           },
           {
             "tab": "デペロッパーポータル",
-            "pages": ["ja/s/article/Developer-Portal-Redirect"]
+            "pages": [
+              "ja/s/article/Developer-Portal-Redirect"
+            ]
           },
           {
             "tab": "リリースノート",

--- a/s/article/000006094.mdx
+++ b/s/article/000006094.mdx
@@ -1,0 +1,53 @@
+---
+title: "Sansan Connector"
+excerpt: "Connect your Sansan business card management account to Domo using an API key."
+---
+
+## Intro
+
+Sansan is a business card management service. To learn more about the Sansan APIs, visit the [Sansan API documentation](https://docs.ap.sansan.com/en/api/).
+
+Use of the Sansan Open API is subject to the [Sansan API Terms of Use](https://agreement.sansan.com/en/rule/api.html), and use of the API constitutes acceptance of the Sansan API Terms of Service.
+
+You can connect to your Sansan account in the Data Center. This article covers the fields and menus that are specific to the Sansan connector. To add DataSets, set update schedules, and edit DataSet information, see [Adding a DataSet Using a Connector](/s/article/360042926274).
+
+---
+
+## Prerequisites
+
+To connect to your Sansan account and create a DataSet, you need the API key associated with your Sansan account.
+
+To find your API key, see [Steps for using Sansan APIs](https://docs.ap.sansan.com/en/api/index.html).
+
+## Connect to Your Sansan Account
+
+This section enumerates the options in the **Credentials** and **Details** panes on the Sansan Connector page. The components of the other panes on this page, **Scheduling** and **Name & Describe Your DataSet**, are universal across most connector types and are discussed in detail in [Adding a DataSet Using a Connector](/s/article/360042926274).
+
+## Credentials Pane
+
+This pane contains fields for entering credentials to connect to your Sansan account. The following table describes what is needed for each field:
+
+| Field   | Description                                            |
+| ------- | ------------------------------------------------------ |
+| API Key | Enter the API key associated with your Sansan account. |
+
+Once you have entered valid Sansan credentials, you can use the same account at any time to create a new Sansan DataSet. You can manage connector accounts in the **Accounts** tab in the Data Center. For more information about this tab, see [Manage Connector Accounts](/s/article/360042926054).
+
+## Details Pane
+
+This pane contains a primary **Reports** menu, along with various other menus that may or may not appear depending on the report type you select.
+
+| Menu                  | Description                                                                                                                                                                                                                                                                                                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Report                | Select the Sansan report you want to run. The following reports are available:<br/><table><thead><tr><th>Report Name</th><th>Description</th></tr></thead><tbody><tr><td>Business Cards</td><td>Returns the list of business cards accessible in your account.</td></tr><tr><td>Contact</td><td>Returns the list of reports by contact type.</td></tr><tr><td>Users</td><td>Returns the list of all users of your company.</td></tr><tr><td>Departments</td><td>Returns the list of all departments of your company.</td></tr></tbody></table> |
+| Updated               | In the Date selection, select either a single day, a date range, or a time period when filtering the results by the update date of items.<br/>**Single date:** Select the specific or relative single date.<br/>**Date range:** Select the specific or relative date range.<br/>**Time period:** Select the time period from the **Time period** dropdown for your report.                                  |
+| Updated - Date        | Select the **Date Type** to specify whether the report should use a specific date or a relative number of days from today.<br/>**Relative**: Enter the number of days back in the **Days Back** field. For example, enter **0** for today, **1** for yesterday, or **7** for data from the past seven days.<br/>**Specific**: Select a date using the date picker in the **Date** field.                   |
+| Updated - Start Date  | Select the **Date Type** for your report:<br/>**Relative**: Enter the number of days back to use as the start date. Use this together with **End Date** to define the date range. *Example*: If you enter **10** for **Start Date** and **5** for **End Date**, the report includes data from 10 days ago through 5 days ago.<br/>**Specific**: Select the first date in the range using the date selector. |
+| Updated - End Date    | Select the **Date Type** for your report:<br/>**Relative**: Enter the number of days back to use as the end date. Use this together with **Start Date** to define the date range. *Example*: If you enter **10** for **Start Date** and **5** for **End Date**, the report includes data from 10 days ago through 5 days ago.<br/>**Specific**: Select the last date in the range using the date selector.   |
+| Updated - Time period | Choose the time period for which you want to receive the data.                                                                                                                                                                                                                                                                                                                                            |
+| Contact type          | Select the contact type. The available options are **Meeting**, **Call**, **Email**, **BizCardExchange**, and **OnlineMeeting**.                                                                                                                                                                                                                                                                           |
+| Category type         | Select whether you want to apply category filters.                                                                                                                                                                                                                                                                                                                                                        |
+
+## Other Panes
+
+For information about the remaining sections of the connector interface, including how to configure scheduling, retry, and update options, see [Adding a DataSet Using a Connector](/s/article/360042926274).

--- a/s/article/360043437633.mdx
+++ b/s/article/360043437633.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Connecting to Sage 300 Data in Domo"
+title: "Sage 300 Data in Domo"
 excerpt: "Connect to Sage 300 data in Domo using the Sage ODBC driver in Workbench or by replicating data with Anterra Data Center."
 ---
 


### PR DESCRIPTION
## Summary

- Adds new KB article for the Sansan Connector (`s/article/000006094.mdx`) — a business card management service from Japan. Covers prerequisites (API key), Credentials pane, and Details pane including a nested reports table.
- Registers the article in `docs.json` under **Data Providers Q–S**, alphabetically between Salesforce and SAP.
- Alphabetizes all named sub-groups (Adobe, Cvent, TikTok, etc.) within each **Data Providers** nav group so they sort correctly alongside standalone articles rather than stacking at the bottom.
- Renames `s/article/360043437633.mdx` title from "Connecting to Sage 300 Data in Domo" → "Sage 300 Data in Domo" (imperative-mood style rule) and repositions it in the nav to match the new title.
- Adds a `migrate-html` skill to `.claude/skills/` documenting the HTML → MDX migration pipeline for future use.

## Test plan

- [x] Confirm Sansan Connector article renders correctly at its nav path in a Mintlify preview
- [x] Spot-check Data Providers groups (A–B, C–F, G–K, L–P, Q–S, T–Z) in the sidebar — sub-groups should now appear in alphabetical order among standalone articles
- [x] Confirm "Sage 300 Data in Domo" appears correctly titled and in the right nav slot (after QuickBooks, before Sage Intacct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)