### PR TITLE
feat: add CODEOWNERS for notification-only PM review routing

### DIFF
--- a/.claude/skills/update-pm-ownership/SKILL.md
+++ b/.claude/skills/update-pm-ownership/SKILL.md
@@ -166,12 +166,52 @@ If the user reports a specific mis-assignment (e.g. "article X should be Feature
 
 ---
 
-## Step 7: Commit
+## Step 7: Update CODEOWNERS
+
+After regenerating `Article-PM-Ownership-Reference.mdx`, update `.github/CODEOWNERS` to reflect any changes.
+
+**When PM assignments change (articles reassigned to a different PM):**
+
+1. For each reassigned article, find its current line in `.github/CODEOWNERS` and update the login:
+   ```
+   s/article/filename.mdx @old-login  →  s/article/filename.mdx @new-login
+   ```
+2. If the new PM doesn't have a GitHub login in the mapping table at the top of CODEOWNERS, add a placeholder comment under "Skipped PMs" and skip their entries for now.
+
+**When new articles are added:**
+
+For each new article that belongs to a PM with a confirmed GitHub login, add a line under that PM's section:
+```
+s/article/new-filename.mdx @github-login
+```
+
+Consult the PM → GitHub login mapping table at the top of `.github/CODEOWNERS` to find the correct login.
+
+**When articles are renamed or removed:**
+
+Update or delete the corresponding line in `.github/CODEOWNERS`.
+
+**When a new PM is added or an existing PM gets a GitHub login:**
+
+1. Add the PM to the mapping table at the top of `.github/CODEOWNERS`:
+   ```
+   #   New PM Name   → @their-github-login
+   ```
+2. Remove their name from the "Skipped PMs" comment if present.
+3. Add article entries for all of their articles under a new section header:
+   ```
+   # ── New PM Name (@their-github-login) ────────────────────────────────────
+   s/article/filename.mdx @their-github-login
+   ```
+
+---
+
+## Step 8: Commit
 
 After the user confirms the output looks correct:
 
 ```bash
-git add Article-PM-Ownership-Reference.mdx scripts/build-pm-ownership.py
+git add Article-PM-Ownership-Reference.mdx scripts/build-pm-ownership.py .github/CODEOWNERS
 ```
 
 Commit message format:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,313 @@
+# CODEOWNERS — notification-only routing for KB article reviews.
+#
+# When a PR touches a file listed here, GitHub automatically requests
+# a review from the listed PM. Branch protection on main does NOT
+# require code-owner approval — this is for visibility routing only.
+#
+# PM → GitHub login mapping (update this table when PMs are added or change):
+#   Andrea Henderson   → @ahenderson-domo
+#   Dan Brinton        → @OriginalDanB
+#   Ken Boyer          → @bikene1
+#   Mamta Bolaki       → @mamtabolaki-gif
+#   Phil Fuchs         → @phil-fuchs-domo
+#   Ryan Despain       → @RyanDespain
+#
+# Skipped PMs (no GitHub login confirmed — add login and entries when available):
+#   Beth Saenz, Chris Wright, Jordan Jensen, Khushboo,
+#   Mark Adams, Tasleema Lallmamode
+#
+# To update after regenerating Article-PM-Ownership-Reference.mdx:
+#   See .claude/skills/update-pm-ownership/SKILL.md § Update CODEOWNERS
+
+# ── Andrea Henderson (@ahenderson-domo) ──────────────────────────────────────
+s/article/360060598413.mdx @ahenderson-domo
+s/article/000005502.mdx @ahenderson-domo
+s/article/360048127854.mdx @ahenderson-domo
+s/article/4410213098903.mdx @ahenderson-domo
+s/article/360063698733.mdx @ahenderson-domo
+s/article/000005216.mdx @ahenderson-domo
+s/article/360043428073.mdx @ahenderson-domo
+s/article/360042923174.mdx @ahenderson-domo
+s/article/360042923154.mdx @ahenderson-domo
+s/article/360042923134.mdx @ahenderson-domo
+s/article/360042922994.mdx @ahenderson-domo
+s/article/360042923414.mdx @ahenderson-domo
+s/article/360043428133.mdx @ahenderson-domo
+s/article/360042923094.mdx @ahenderson-domo
+s/article/360043437753.mdx @ahenderson-domo
+s/article/360042923234.mdx @ahenderson-domo
+s/article/360043427953.mdx @ahenderson-domo
+s/article/4404652354583.mdx @ahenderson-domo
+s/article/360043428153.mdx @ahenderson-domo
+s/article/360043428173.mdx @ahenderson-domo
+s/article/360043427833.mdx @ahenderson-domo
+s/article/360042922954.mdx @ahenderson-domo
+s/article/360043427793.mdx @ahenderson-domo
+s/article/4405318926231.mdx @ahenderson-domo
+s/article/360042923014.mdx @ahenderson-domo
+s/article/360042923494.mdx @ahenderson-domo
+s/article/360042922974.mdx @ahenderson-domo
+s/article/360042923034.mdx @ahenderson-domo
+s/article/360043427893.mdx @ahenderson-domo
+s/article/360042923054.mdx @ahenderson-domo
+s/article/360042923074.mdx @ahenderson-domo
+s/article/360047787514.mdx @ahenderson-domo
+s/article/360055259234.mdx @ahenderson-domo
+s/article/360043428113.mdx @ahenderson-domo
+s/article/360057087393.mdx @ahenderson-domo
+s/article/000005150.mdx @ahenderson-domo
+s/article/000005541.mdx @ahenderson-domo
+s/article/360043427653.mdx @ahenderson-domo
+s/article/8276764172951.mdx @ahenderson-domo
+s/article/360045163773.mdx @ahenderson-domo
+s/article/360043427933.mdx @ahenderson-domo
+s/article/360051062653.mdx @ahenderson-domo
+s/article/360043427693.mdx @ahenderson-domo
+s/article/000005557.mdx @ahenderson-domo
+s/article/000005455.mdx @ahenderson-domo
+s/article/4422644650519.mdx @ahenderson-domo
+s/article/360044876094.mdx @ahenderson-domo
+s/article/000005741.mdx @ahenderson-domo
+s/article/360044876194.mdx @ahenderson-domo
+s/article/360045259294.mdx @ahenderson-domo
+s/article/360045402273.mdx @ahenderson-domo
+s/article/360045402313.mdx @ahenderson-domo
+s/article/000005901.mdx @ahenderson-domo
+s/article/360044876614.mdx @ahenderson-domo
+s/article/000006036.mdx @ahenderson-domo
+s/article/4405156517527.mdx @ahenderson-domo
+s/article/360044951294.mdx @ahenderson-domo
+s/article/360045485833.mdx @ahenderson-domo
+s/article/000005919.mdx @ahenderson-domo
+s/article/360045402873.mdx @ahenderson-domo
+s/article/360044876874.mdx @ahenderson-domo
+s/article/000005117.mdx @ahenderson-domo
+s/article/360043427733.mdx @ahenderson-domo
+s/article/360043427753.mdx @ahenderson-domo
+s/article/360043427713.mdx @ahenderson-domo
+s/article/360043427353.mdx @ahenderson-domo
+s/article/360043427373.mdx @ahenderson-domo
+s/article/4405652887191.mdx @ahenderson-domo
+s/article/360042922814.mdx @ahenderson-domo
+s/article/360043427773.mdx @ahenderson-domo
+s/article/000005815.mdx @ahenderson-domo
+s/article/Query-DataSet-Tile.mdx @ahenderson-domo
+s/article/360042923534.mdx @ahenderson-domo
+s/article/4662034775319.mdx @ahenderson-domo
+s/article/4662355030423.mdx @ahenderson-domo
+s/article/000005826.mdx @ahenderson-domo
+s/article/360044289573.mdx @ahenderson-domo
+s/article/4662511363351.mdx @ahenderson-domo
+s/article/4408794063639.mdx @ahenderson-domo
+s/article/000005860.mdx @ahenderson-domo
+s/article/360044296573.mdx @ahenderson-domo
+s/article/360044258533.mdx @ahenderson-domo
+
+# ── Dan Brinton (@OriginalDanB) ──────────────────────────────────────────────
+s/article/360042934274.mdx @OriginalDanB
+s/article/360042934234.mdx @OriginalDanB
+s/article/000005164.mdx @OriginalDanB
+s/article/5428851518999.mdx @OriginalDanB
+s/article/360043438933.mdx @OriginalDanB
+s/article/360042934294.mdx @OriginalDanB
+s/article/360043427533.mdx @OriginalDanB
+s/article/000005326.mdx @OriginalDanB
+s/article/360043427493.mdx @OriginalDanB
+s/article/360042922894.mdx @OriginalDanB
+s/article/360042922874.mdx @OriginalDanB
+s/article/360043427453.mdx @OriginalDanB
+s/article/000005902.mdx @OriginalDanB
+s/article/360043438893.mdx @OriginalDanB
+s/article/360043438973.mdx @OriginalDanB
+s/article/000005510.mdx @OriginalDanB
+s/article/360042934334.mdx @OriginalDanB
+s/article/000005839.mdx @OriginalDanB
+s/article/360042922914.mdx @OriginalDanB
+s/article/000005616.mdx @OriginalDanB
+s/article/360043427473.mdx @OriginalDanB
+s/article/360043427573.mdx @OriginalDanB
+s/article/360043430373.mdx @OriginalDanB
+s/article/360042925814.mdx @OriginalDanB
+s/article/360042925994.mdx @OriginalDanB
+s/article/360043430513.mdx @OriginalDanB
+s/article/360043430533.mdx @OriginalDanB
+s/article/360042934634.mdx @OriginalDanB
+s/article/360042925974.mdx @OriginalDanB
+s/article/360042934574.mdx @OriginalDanB
+s/article/000005240.mdx @OriginalDanB
+s/article/000005241.mdx @OriginalDanB
+s/article/000005432.mdx @OriginalDanB
+s/article/360043430273.mdx @OriginalDanB
+s/article/360043429973.mdx @OriginalDanB
+s/article/360043430613.mdx @OriginalDanB
+s/article/360042925734.mdx @OriginalDanB
+s/article/360043430293.mdx @OriginalDanB
+s/article/360043430313.mdx @OriginalDanB
+s/article/360042925754.mdx @OriginalDanB
+s/article/360042925774.mdx @OriginalDanB
+s/article/360042925794.mdx @OriginalDanB
+s/article/360042925574.mdx @OriginalDanB
+s/article/000005492.mdx @OriginalDanB
+s/article/000005280.mdx @OriginalDanB
+s/article/360042934594.mdx @OriginalDanB
+s/article/360043439293.mdx @OriginalDanB
+s/article/360043439273.mdx @OriginalDanB
+s/article/360043439313.mdx @OriginalDanB
+s/article/DomoStats-Overview.mdx @OriginalDanB
+s/article/4577793742615.mdx @OriginalDanB
+s/article/4577172785559.mdx @OriginalDanB
+s/article/4578049721495.mdx @OriginalDanB
+s/article/4578278680855.mdx @OriginalDanB
+s/article/4663374299031.mdx @OriginalDanB
+s/article/360043439393.mdx @OriginalDanB
+s/article/360043427513.mdx @OriginalDanB
+s/article/360043439433.mdx @OriginalDanB
+s/article/360042934674.mdx @OriginalDanB
+s/article/360042934714.mdx @OriginalDanB
+s/article/360042925954.mdx @OriginalDanB
+s/article/360043439413.mdx @OriginalDanB
+s/article/360043439453.mdx @OriginalDanB
+s/article/000005827.mdx @OriginalDanB
+s/article/360043438033.mdx @OriginalDanB
+s/article/360043438053.mdx @OriginalDanB
+s/article/360043438133.mdx @OriginalDanB
+s/article/360043438213.mdx @OriginalDanB
+
+# ── Ken Boyer (@bikene1) ─────────────────────────────────────────────────────
+s/article/AI-Admin-Agent-Settings.mdx @bikene1
+s/article/AI-Admin-Settings.mdx @bikene1
+s/article/AI-Chat-DataSet-Restrictions.mdx @bikene1
+s/article/AI-Library.mdx @bikene1
+s/article/AI-Model-Version-Differences.mdx @bikene1
+s/article/000005561.mdx @bikene1
+s/article/000005851.mdx @bikene1
+s/article/000005279.mdx @bikene1
+s/article/Configure-Agent-Role-and-Instructions.mdx @bikene1
+s/article/Connect-AI-Tools-to-Domo-Using-MCP.mdx @bikene1
+s/article/000005291.mdx @bikene1
+s/article/Create-and-Use-Data-Models.mdx @bikene1
+s/article/Credit-Usage-Stats-Report-AI-Fields.mdx @bikene1
+s/article/Domo-AI-FAQ.mdx @bikene1
+s/article/000005236.mdx @bikene1
+s/article/000005918.mdx @bikene1
+s/article/000005567.mdx @bikene1
+s/article/000005853.mdx @bikene1
+s/article/000005724.mdx @bikene1
+s/article/Magic-ETL-AI.mdx @bikene1
+s/article/000005539.mdx @bikene1
+s/article/Access-Tokens.mdx @bikene1
+s/article/Amazon-S3-Connector.mdx @bikene1
+s/article/Confluence-Connector.mdx @bikene1
+s/article/Documents.mdx @bikene1
+s/article/GitHub-Connector.mdx @bikene1
+s/article/Google-Drive-Connector.mdx @bikene1
+s/article/SFTP-Connector.mdx @bikene1
+s/article/000005849.mdx @bikene1
+s/article/7440921035671.mdx @bikene1
+s/article/000005544.mdx @bikene1
+s/article/000005166.mdx @bikene1
+
+# ── Mamta Bolaki (@mamtabolaki-gif) ──────────────────────────────────────────
+s/article/360043437993.mdx @mamtabolaki-gif
+s/article/4492108625687.mdx @mamtabolaki-gif
+s/article/4418999855639.mdx @mamtabolaki-gif
+s/article/000005814.mdx @mamtabolaki-gif
+s/article/360045120554.mdx @mamtabolaki-gif
+s/article/4434678124695.mdx @mamtabolaki-gif
+s/article/6523741250455.mdx @mamtabolaki-gif
+s/article/000005786.mdx @mamtabolaki-gif
+s/article/4403367344023.mdx @mamtabolaki-gif
+s/article/000005059.mdx @mamtabolaki-gif
+
+# ── Phil Fuchs (@phil-fuchs-domo) ────────────────────────────────────────────
+s/article/000005304.mdx @phil-fuchs-domo
+s/article/360043430053.mdx @phil-fuchs-domo
+s/article/4408174643607.mdx @phil-fuchs-domo
+s/article/360043429933.mdx @phil-fuchs-domo
+s/article/360042925474.mdx @phil-fuchs-domo
+s/article/360042925434.mdx @phil-fuchs-domo
+s/article/360043429913.mdx @phil-fuchs-domo
+s/article/360043429953.mdx @phil-fuchs-domo
+s/article/000005307.mdx @phil-fuchs-domo
+s/article/360043430073.mdx @phil-fuchs-domo
+s/article/360043430093.mdx @phil-fuchs-domo
+s/article/360042925494.mdx @phil-fuchs-domo
+s/article/360042925514.mdx @phil-fuchs-domo
+s/article/360043430113.mdx @phil-fuchs-domo
+s/article/360043430133.mdx @phil-fuchs-domo
+s/article/360043430153.mdx @phil-fuchs-domo
+s/article/000005559.mdx @phil-fuchs-domo
+s/article/360042923754.mdx @phil-fuchs-domo
+s/article/4403501587607.mdx @phil-fuchs-domo
+s/article/360042935314.mdx @phil-fuchs-domo
+s/article/360042926154.mdx @phil-fuchs-domo
+s/article/360042935354.mdx @phil-fuchs-domo
+s/article/360042935374.mdx @phil-fuchs-domo
+s/article/360042926074.mdx @phil-fuchs-domo
+s/article/360043430653.mdx @phil-fuchs-domo
+s/article/360042934254.mdx @phil-fuchs-domo
+s/article/360047553253.mdx @phil-fuchs-domo
+s/article/4405337525783.mdx @phil-fuchs-domo
+s/article/000005946.mdx @phil-fuchs-domo
+s/article/360043430733.mdx @phil-fuchs-domo
+s/article/360042926194.mdx @phil-fuchs-domo
+s/article/360043437733.mdx @phil-fuchs-domo
+s/article/360043437693.mdx @phil-fuchs-domo
+s/article/360042926214.mdx @phil-fuchs-domo
+s/article/360042926134.mdx @phil-fuchs-domo
+s/article/360042926054.mdx @phil-fuchs-domo
+s/article/000005675.mdx @phil-fuchs-domo
+s/article/360056727214.mdx @phil-fuchs-domo
+s/article/4434784751767.mdx @phil-fuchs-domo
+s/article/360042934614.mdx @phil-fuchs-domo
+s/article/360043435533.mdx @phil-fuchs-domo
+s/article/360042926114.mdx @phil-fuchs-domo
+s/article/360043430713.mdx @phil-fuchs-domo
+s/article/360043428693.mdx @phil-fuchs-domo
+s/article/360051558694.mdx @phil-fuchs-domo
+s/article/360043430413.mdx @phil-fuchs-domo
+s/article/360042926234.mdx @phil-fuchs-domo
+s/article/4402058407191.mdx @phil-fuchs-domo
+s/article/360046074774.mdx @phil-fuchs-domo
+s/article/360043428293.mdx @phil-fuchs-domo
+s/article/360043428333.mdx @phil-fuchs-domo
+s/article/360043428313.mdx @phil-fuchs-domo
+s/article/360042924834.mdx @phil-fuchs-domo
+s/article/000005156.mdx @phil-fuchs-domo
+
+# ── Ryan Despain (@RyanDespain) ──────────────────────────────────────────────
+s/article/360042926034.mdx @RyanDespain
+s/article/360043430593.mdx @RyanDespain
+s/article/Content-Governance-Hub.mdx @RyanDespain
+s/article/4415792998935.mdx @RyanDespain
+s/article/000005105.mdx @RyanDespain
+s/article/000005197.mdx @RyanDespain
+s/article/4415839663639.mdx @RyanDespain
+s/article/8275510785559.mdx @RyanDespain
+s/article/4415800746391.mdx @RyanDespain
+s/article/6814561223959.mdx @RyanDespain
+s/article/4415839139863.mdx @RyanDespain
+s/article/9301034807575.mdx @RyanDespain
+s/article/6305057013527.mdx @RyanDespain
+s/article/4415826269335.mdx @RyanDespain
+s/article/360042925854.mdx @RyanDespain
+s/article/360042925934.mdx @RyanDespain
+s/article/360043430333.mdx @RyanDespain
+s/article/360042925874.mdx @RyanDespain
+s/article/360042925834.mdx @RyanDespain
+s/article/360042925894.mdx @RyanDespain
+s/article/360043430473.mdx @RyanDespain
+s/article/360042925914.mdx @RyanDespain
+s/article/360043430493.mdx @RyanDespain
+s/article/360043430353.mdx @RyanDespain
+s/article/000005865.mdx @RyanDespain
+s/article/000005173.mdx @RyanDespain
+s/article/000005331.mdx @RyanDespain
+s/article/000005171.mdx @RyanDespain
+s/article/000005179.mdx @RyanDespain
+s/article/000005172.mdx @RyanDespain
+s/article/360043437773.mdx @RyanDespain
+s/article/000005396.mdx @RyanDespain
+s/article/000005930.mdx @RyanDespain
+s/article/000005842.mdx @RyanDespain
+s/article/000005369.mdx @RyanDespain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Every article in `s/article/` is mapped to a **Feature** (using the same nomencl
 - **Reference file:** `Article-PM-Ownership-Reference.mdx` — searchable table of Feature, Article Title, Article File Name, PM.
 - **Source CSV:** `Feature - Owning Squad, PM, Eng, UX.csv` — authoritative squad/PM roster; the Feature column is the canonical identifier used in the reference.
 - **Generation script:** `scripts/build-pm-ownership.py` — regenerates the reference by cross-referencing the CSV against `docs.json` navigation hierarchy and article frontmatter. Re-run whenever articles are added in bulk or the CSV changes.
+- **CODEOWNERS:** `.github/CODEOWNERS` — maps article files to GitHub logins for notification-only review routing. When a PR touches a listed file, GitHub auto-requests a review from the assigned PM. The PM → GitHub login mapping table is in the file header. Update this file whenever `Article-PM-Ownership-Reference.mdx` is regenerated (see the `update-pm-ownership` skill).
 
 To look up who owns a specific article:
 ```bash


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` mapping 281 KB articles across 6 PMs to their GitHub logins
- Routing is **notification-only** — branch protection on `main` does not require code-owner approval; this is for visibility routing so the right PM is auto-requested as a reviewer when their articles are touched
- Updates the `update-pm-ownership` skill to include CODEOWNERS sync instructions as part of the ownership regeneration workflow
- Adds a CODEOWNERS reference to `CLAUDE.md` under the Article PM Ownership section

**PMs covered:** Andrea Henderson, Dan Brinton, Ken Boyer, Mamta Bolaki, Phil Fuchs, Ryan Despain

**Skipped (no GitHub login confirmed):** Beth Saenz, Chris Wright, Jordan Jensen, Khushboo, Mark Adams, Tasleema Lallmamode — placeholders noted in the file header; entries can be added once logins are confirmed and those users are added as repo collaborators.

## Test plan

- [ ] Confirm `.github/CODEOWNERS` is recognized by GitHub (visible under repo Settings → Code and automation → Code owners)
- [ ] Open a test PR touching one of the listed articles and verify the correct PM is auto-requested as a reviewer
- [ ] Confirm merging is not blocked when the code owner hasn't reviewed (notification-only behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)