### PR TITLE
docs: add v2.9.0 release notes

### DIFF
--- a/releaseNotes/v2.9.0.mdx
+++ b/releaseNotes/v2.9.0.mdx
@@ -1,0 +1,89 @@
+---
+title: "Domo Documentation Hub v2.9.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.9.0 of the Domo Documentation Hub is now available! This release is headlined by a significantly expanded MCP Server setup guide, two new connector articles, a developer API rebrand, and a major batch of new microlearning videos. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🤖 MCP Server: Full OAuth Setup Guide with Screenshots
+
+The "Connect AI Tools to Domo Using MCP" article has been substantially expanded into a step-by-step OAuth setup guide. It now walks users through retrieving the MCP server URL from the AI Library, adding a custom connector in Claude Desktop, and authenticating with OAuth — with nine new screenshots illustrating each step. A new OAuth FAQ section covers common questions about domains, permissions, and troubleshooting. A post-connection capabilities section was also added to describe what users can do once connected.
+
+Learn more about [connecting AI tools to Domo using MCP](https://www.domo.com/docs/s/article/Connect-AI-Tools-to-Domo-Using-MCP).
+
+Thanks to Ken Boyer and Jared Peterson for the expanded guide and new visual assets.
+
+### 🔌 New Connector Articles: Sansan and OpenAI Administration
+
+Two new connector KB articles are now live. The Sansan Connector article covers connecting Domo to Sansan's business card management service via API key, including required grants, credential fields, and available reports. The OpenAI Administration Connector article explains how to pull OpenAI organization administration data — including audit logs, users, projects, API keys, usage, and costs — using an Admin API key with appropriate organization scopes.
+
+See the new [Sansan Connector](https://www.domo.com/docs/s/article/000006094) and [OpenAI Administration Connector](https://www.domo.com/docs/s/article/OpenAI-Administration-Connector) articles.
+
+Thanks to Arun Raj for authoring both articles.
+
+### 📄 Documents API: Filesets Rebranded and Out of Beta
+
+Both the Product API and App Framework API "Filesets" documentation have been renamed to **Documents API** and the Beta label has been removed, reflecting the feature's general availability and official branding. The docs.json navigation and internal cross-references have been updated to match.
+
+See the updated [Documents API (Product APIs)](https://www.domo.com/docs/portal/API-Reference/Product-APIs/Documents-API) and [Documents API (App Framework APIs)](https://www.domo.com/docs/portal/API-Reference/app-framework-apis/Documents-API).
+
+Thanks to Ken Boyer for the rebrand and Jared Peterson for the nav updates.
+
+### 🛠 Developer API Improvements
+
+Three developer-facing articles received meaningful documentation improvements this release:
+
+- **AppDB API filter rules** — A new warning block clarifies that all four core filter rule fields (`name`, `applyOn`, `applyTo`, `query`) are required even when empty, and that omitting any of them causes the upload to fail. A minimal working example is now included alongside the explanation. Learn more in the [AppDB API documentation](https://www.domo.com/docs/portal/API-Reference/app-framework-apis/AppDB-API).
+
+- **Datasets API SQL restrictions** — A new note on the query endpoint makes explicit that only read-only SELECT statements are supported, and that INSERT, UPDATE, DELETE, and MERGE statements will not execute. Users who need to ingest or update data are directed to the Streams API. See the [Datasets API reference](https://www.domo.com/docs/portal/35115c5c48927-datasets-api).
+
+- **Snowflake Key Pair Authentication** — The public/private key pair setup section has been rewritten for clarity, with distinct sub-sections for generating unencrypted vs. encrypted private keys, cleaner command formatting, and a more logical step sequence. Read the updated [Snowflake Key Pair Authentication Connector](https://www.domo.com/docs/s/article/360042931854) article.
+
+Thanks to Bradley Turek for the AppDB improvements, Felipe Suarez for the Datasets API clarification, and Arun Raj for the Snowflake article rewrite.
+
+### 📋 Connector Article Updates
+
+Several existing connector articles received content additions and polish:
+
+- **Cvent REST Connector** — A comprehensive reports reference table listing 60+ available reports (Air Actual, Attendees, Budget Items, Sessions, Speakers, Transactions, and more) was added to the Details pane documentation. See the updated [Cvent REST Connector](https://www.domo.com/docs/s/article/4411277235351).
+
+- **SFTP Writeback Connector** — The credential setup steps have been streamlined. The inline instructions for obtaining a Domo Client ID and Secret were replaced with a direct link to the canonical guide, reducing duplication and keeping the article easier to maintain.
+
+- Minor link and text fixes were applied to the Gong, Azure DevOps, Asana, Conductor Searchlight, Vibe, Entrata, Shopify, Dataset via Email, Sage 300, Google BigQuery, and Facebook Advanced connector articles.
+
+Thanks to Arun Raj for the connector article additions and polish.
+
+### 🎬 Domo Video Library — 13 New Microlearning Videos
+
+The [Domo Video Library](https://www.domo.com/docs/s/article/Domo-Video-Library) has been updated with 13 new microlearning videos covering a wide range of platform topics, all added in June 2026:
+
+- App Studio Overview
+- Automate Magic ETL Dataflows Using Triggers and Schedules
+- Create Custom Roles and Assign Grants in Domo
+- Dashboards Overview
+- Domo Everywhere: Embed Overview
+- Domo Publish Overview
+- Domo's Data Transformation Tools (4-part series: Overview, Magic ETL, Dataset Views, Beast Mode)
+- Explore Data Integration Options in Domo
+- Govern Data Access with Row- and Column-Based PDP
+- Govern User Access in Domo with Roles, SSO, and Automation
+- Magic ETL Dataflows: The History and Version Tabs
+- Monitor Your Domo Instance with DomoStats
+- Understanding Accounts for Secure Credential Storage and Sharing
+- Understanding Domo's AI Architecture: From Models to Agentic Solutions
+- Understanding Update Methods in Domo: Replace, Append, Upsert, and Partition
+
+### 🧩 DomoEmbed Snippet Component
+
+A new reusable `DomoEmbed` MDX snippet has been added to the `snippets/` directory. Article authors can now import `<DomoEmbed src="..." />` to embed Domo-hosted cards or pages in any KB article, with automatic iframe height-resize to eliminate scroll traps. The Domo KB Style Guide and New Article Template have been updated to document the component and its props.
+
+Thanks to Jonathan Tiritilli for building the component and Jared Peterson for updating the style guide.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who contributed to this release — from Arun Raj's steady stream of connector articles and updates, to Ken Boyer and Jared Peterson's MCP and API documentation work, to Bradley Turek and Felipe Suarez's developer-facing improvements, and to Jonathan Tiritilli's new snippet component. Every contribution moves the docs forward for our users.
+
+If you have questions or feedback, please reach out — we're always happy to help!

--- a/releaseNotesExternal/v2.9.0.mdx
+++ b/releaseNotesExternal/v2.9.0.mdx
@@ -1,0 +1,73 @@
+---
+title: "Domo Documentation Hub v2.9.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.9.0 of the Domo Documentation Hub is now available! This release is headlined by a significantly expanded MCP Server setup guide, two new connector articles, a developer API rebrand, and a major batch of new microlearning videos. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🤖 MCP Server: Full OAuth Setup Guide with Screenshots
+
+The "Connect AI Tools to Domo Using MCP" article has been substantially expanded into a step-by-step OAuth setup guide. It now walks users through retrieving the MCP server URL from the AI Library, adding a custom connector in Claude Desktop, and authenticating with OAuth — with nine new screenshots illustrating each step. A new OAuth FAQ section covers common questions about domains, permissions, and troubleshooting. A post-connection capabilities section was also added to describe what users can do once connected.
+
+Learn more about [connecting AI tools to Domo using MCP](https://www.domo.com/docs/s/article/Connect-AI-Tools-to-Domo-Using-MCP).
+
+### 🔌 New Connector Articles: Sansan and OpenAI Administration
+
+Two new connector KB articles are now live. The Sansan Connector article covers connecting Domo to Sansan's business card management service via API key, including required grants, credential fields, and available reports. The OpenAI Administration Connector article explains how to pull OpenAI organization administration data — including audit logs, users, projects, API keys, usage, and costs — using an Admin API key with appropriate organization scopes.
+
+See the new [Sansan Connector](https://www.domo.com/docs/s/article/000006094) and [OpenAI Administration Connector](https://www.domo.com/docs/s/article/OpenAI-Administration-Connector) articles.
+
+### 📄 Documents API: Filesets Rebranded and Out of Beta
+
+Both the Product API and App Framework API "Filesets" documentation have been renamed to **Documents API** and the Beta label has been removed, reflecting the feature's general availability and official branding. The navigation and internal cross-references have been updated to match.
+
+See the updated [Documents API (Product APIs)](https://www.domo.com/docs/portal/API-Reference/Product-APIs/Documents-API) and [Documents API (App Framework APIs)](https://www.domo.com/docs/portal/API-Reference/app-framework-apis/Documents-API).
+
+### 🛠 Developer API Improvements
+
+Three developer-facing articles received meaningful documentation improvements this release:
+
+- **AppDB API filter rules** — A new warning block clarifies that all four core filter rule fields (`name`, `applyOn`, `applyTo`, `query`) are required even when empty, and that omitting any of them causes the upload to fail. A minimal working example is now included alongside the explanation. Learn more in the [AppDB API documentation](https://www.domo.com/docs/portal/API-Reference/app-framework-apis/AppDB-API).
+
+- **Datasets API SQL restrictions** — A new note on the query endpoint makes explicit that only read-only SELECT statements are supported, and that INSERT, UPDATE, DELETE, and MERGE statements will not execute. Users who need to ingest or update data are directed to the Streams API. See the [Datasets API reference](https://www.domo.com/docs/portal/35115c5c48927-datasets-api).
+
+- **Snowflake Key Pair Authentication** — The public/private key pair setup section has been rewritten for clarity, with distinct sub-sections for generating unencrypted vs. encrypted private keys, cleaner command formatting, and a more logical step sequence. Read the updated [Snowflake Key Pair Authentication Connector](https://www.domo.com/docs/s/article/360042931854) article.
+
+### 📋 Connector Article Updates
+
+Several existing connector articles received content additions and polish:
+
+- **Cvent REST Connector** — A comprehensive reports reference table listing 60+ available reports (Air Actual, Attendees, Budget Items, Sessions, Speakers, Transactions, and more) was added to the Details pane documentation. See the updated [Cvent REST Connector](https://www.domo.com/docs/s/article/4411277235351).
+
+- **SFTP Writeback Connector** — The credential setup steps have been streamlined. The inline instructions for obtaining a Domo Client ID and Secret were replaced with a direct link to the canonical guide, reducing duplication and keeping the article easier to maintain.
+
+- Minor link and text fixes were applied to the Gong, Azure DevOps, Asana, Conductor Searchlight, Vibe, Entrata, Shopify, Dataset via Email, Sage 300, Google BigQuery, and Facebook Advanced connector articles.
+
+### 🎬 Domo Video Library — 13 New Microlearning Videos
+
+The [Domo Video Library](https://www.domo.com/docs/s/article/Domo-Video-Library) has been updated with 13 new microlearning videos covering a wide range of platform topics, all added in June 2026:
+
+- App Studio Overview
+- Automate Magic ETL Dataflows Using Triggers and Schedules
+- Create Custom Roles and Assign Grants in Domo
+- Dashboards Overview
+- Domo Everywhere: Embed Overview
+- Domo Publish Overview
+- Domo's Data Transformation Tools (4-part series: Overview, Magic ETL, Dataset Views, Beast Mode)
+- Explore Data Integration Options in Domo
+- Govern Data Access with Row- and Column-Based PDP
+- Govern User Access in Domo with Roles, SSO, and Automation
+- Magic ETL Dataflows: The History and Version Tabs
+- Monitor Your Domo Instance with DomoStats
+- Understanding Accounts for Secure Credential Storage and Sharing
+- Understanding Domo's AI Architecture: From Models to Agentic Solutions
+- Understanding Update Methods in Domo: Replace, Append, Upsert, and Partition
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who helped make this release possible. Your contributions make Domo's documentation better for everyone.
+
+If you have questions or feedback, please reach out — we're always happy to help!


### PR DESCRIPTION
## Summary

- Adds `releaseNotes/v2.9.0.mdx` — internal version with contributor attribution
- Adds `releaseNotesExternal/v2.9.0.mdx` — external/customer-facing version with attribution and author-tooling themes stripped

**Covers `v2.8.0..v2.9.0`**. Key themes:
- 🤖 MCP Server OAuth setup guide expanded with 9 new screenshots and OAuth FAQ
- 🔌 Two new connector articles: Sansan and OpenAI Administration
- 📄 Documents API rebrand (Filesets → Documents, out of Beta)
- 🛠 Developer API improvements: AppDB filter rules warning, Datasets API SQL restriction note, Snowflake Key Pair rewrite
- 📋 Connector article updates: Cvent REST reports table, SFTP Writeback streamlined, 11 articles polished
- 🎬 13 new microlearning videos in the Domo Video Library

## Test plan

- [ ] Verify `releaseNotes/v2.9.0.mdx` renders correctly in Mintlify preview
- [ ] Verify `releaseNotesExternal/v2.9.0.mdx` contains no contributor names or internal-only themes
- [ ] Spot-check article links resolve to valid pages on www.domo.com/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)