### PR TITLE
Add known_approvers support to connector review script

### DIFF
--- a/scripts/connector-review.py
+++ b/scripts/connector-review.py
@@ -326,8 +326,10 @@ def analyze_jira_ticket(jira_id, my_account_id, templates):
             action_type = "publish"
 
     secondary_ids = {a["accountId"] for a in secondary_approvers}
+    known_approver_names = [n.lower() for n in templates.get("known_approvers", [])]
 
-    # Check for secondary approval after Arun's comment
+    # Check for secondary approval after Arun's comment.
+    # Accepts approvals from: (a) accounts Arun @-mentioned, or (b) anyone in known_approvers.
     secondary_approved = False
     past_arun = arun_comment is None  # if no arun comment, scan all
     for c in comments:
@@ -335,8 +337,11 @@ def analyze_jira_ticket(jira_id, my_account_id, templates):
             if c.get("id") == arun_comment.get("id"):
                 past_arun = True
             continue
-        author_id = c.get("author", {}).get("accountId", "")
-        if author_id in secondary_ids:
+        author = c.get("author", {})
+        author_id = author.get("accountId", "")
+        author_name = author.get("displayName", "").lower()
+        is_known = any(kn in author_name for kn in known_approver_names)
+        if author_id in secondary_ids or is_known:
             text = extract_text(c.get("body", {})).lower()
             if any(p in text for p in approval_phrases):
                 secondary_approved = True

--- a/scripts/connector-templates.json
+++ b/scripts/connector-templates.json
@@ -24,6 +24,10 @@
     "marker": "[CONNECTOR-ESCALATION]"
   },
 
+  "known_approvers": [
+    "Nareshkumar Punnam"
+  ],
+
   "approval_phrases": [
     "looks good",
     "look good",


### PR DESCRIPTION
## Summary

- Adds a `known_approvers` list to `connector-templates.json` with Nareshkumar Punnam as the first entry
- Updates `connector-review.py` approval detection to also accept approvals from anyone on the `known_approvers` list (case-insensitive name match), in addition to accounts Arun explicitly @-mentions in the Jira ticket
- Fixes the case where the actual reviewer differs from who Arun tagged

## Adding new approvers

To add a recurring approver in the future, append their display name to `known_approvers` in `connector-templates.json` — no script changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)