### PR TITLE
Detect secondary-approver publish requests as implicit approvals

### DIFF
--- a/scripts/connector-review.py
+++ b/scripts/connector-review.py
@@ -330,6 +330,8 @@ def analyze_jira_ticket(jira_id, my_account_id, templates):
 
     # Check for secondary approval after Arun's comment.
     # Accepts approvals from: (a) accounts Arun @-mentioned, or (b) anyone in known_approvers.
+    # Also treats a secondary's publish/migration request as an implicit approval — when a
+    # reviewer says "please publish it" they have approved and are escalating to Jared.
     secondary_approved = False
     past_arun = arun_comment is None  # if no arun comment, scan all
     for c in comments:
@@ -345,6 +347,14 @@ def analyze_jira_ticket(jira_id, my_account_id, templates):
             text = extract_text(c.get("body", {})).lower()
             if any(p in text for p in approval_phrases):
                 secondary_approved = True
+                break
+            if any(p in text for p in publish_phrases):
+                secondary_approved = True
+                action_type = "publish"
+                break
+            if any(p in text for p in migration_phrases):
+                secondary_approved = True
+                action_type = "migration"
                 break
 
     # Track follow-ups and escalation posted by Jared

--- a/scripts/connector-templates.json
+++ b/scripts/connector-templates.json
@@ -25,7 +25,8 @@
   },
 
   "known_approvers": [
-    "Nareshkumar Punnam"
+    "Nareshkumar Punnam",
+    "Hiren Bhatt"
   ],
 
   "approval_phrases": [
@@ -42,6 +43,8 @@
   "publish_request_phrases": [
     "please publish",
     "publish this",
+    "publish it",
+    "go ahead and publish",
     "ready to publish",
     "please merge"
   ],


### PR DESCRIPTION
## Summary

- When a secondary reviewer comments with a publish/migration phrase (e.g. "please proceed and publish it"), the approval scanner now treats it as both a secondary approval and an action-type signal. Previously only `approval_phrases` were checked, so these comments were invisible to the script — resulting in DOMO-488597 showing as "Awaiting both approvals" when Hiren Bhatt had already commented asking to publish.
- Added "publish it" and "go ahead and publish" to `publish_request_phrases` to cover Hiren's exact wording and common variants.
- Added "Hiren Bhatt" to `known_approvers` so future approvals from him are recognized even if Arun doesn't @-mention him.

## Test plan

- [ ] Run dashboard — DOMO-488597 should now show `Jira approved: ✓`, `Action type: publish`, state `PUBLISH REQUEST`
- [ ] `--auto` should include DOMO-488597 in the merge batch
- [ ] No regression on tickets where secondary used standard approval phrases

🤖 Generated with [Claude Code](https://claude.com/claude-code)