### PR TITLE
Fix incorrect LAST_ALTERED reference in Databricks DataSets docs

### DIFF
--- a/s/article/000005289.mdx
+++ b/s/article/000005289.mdx
@@ -157,7 +157,7 @@ If your catalog or schema does not appear in the dropdowns during write & native
 </Accordion>
 
 <Accordion title="How do Databricks-sourced DataSets work?">
-When a DataFlow uses a Databricks-sourced DataSet, Domo queries the data live from Databricks when the DataFlow runs. Domo checks Databricks-sourced DataSets for updates every 15 minutes using the table's `LAST_ALTERED` timestamp. If Domo detects an update, it triggers any DataFlows that use that table.
+When a DataFlow uses a Databricks-sourced DataSet, Domo queries the data live from Databricks when the DataFlow runs. Domo checks Databricks-sourced DataSets for updates every 15 minutes using the `lastModified` field returned by Databricks's `DESCRIBE DETAIL` command. If Domo detects an update, it triggers any DataFlows that use that table.
 </Accordion>
 
 </AccordionGroup>

--- a/s/article/000005289.mdx
+++ b/s/article/000005289.mdx
@@ -159,7 +159,8 @@ If your catalog or schema does not appear in the dropdowns during write & native
 <Accordion title="How do Databricks-sourced DataSets work?">
 When a DataFlow uses a Databricks-sourced DataSet, Domo queries the data live from Databricks when the DataFlow runs. Domo checks Databricks-sourced DataSets for updates at the configured freshness interval using the `lastModified` field returned by Databricks's `DESCRIBE DETAIL` command. If Domo detects an update, it triggers any DataFlows that use that table.
 
-**Note:** Change detection via `DESCRIBE DETAIL` applies to tables only. Databricks views do not support this check, so Domo treats views as updated on every freshness check cycle — meaning any DataFlow using a Databricks view will be triggered every interval regardless of whether the underlying data changed.
+
+<Note>**Note:** Change detection via `DESCRIBE DETAIL` applies to tables only. Databricks views do not support this check, so Domo treats views as updated on every freshness check cycle — meaning any DataFlow using a Databricks view will be triggered every interval regardless of whether the underlying data changed.</Note>
 </Accordion>
 
 </AccordionGroup>

--- a/s/article/000005289.mdx
+++ b/s/article/000005289.mdx
@@ -157,7 +157,9 @@ If your catalog or schema does not appear in the dropdowns during write & native
 </Accordion>
 
 <Accordion title="How do Databricks-sourced DataSets work?">
-When a DataFlow uses a Databricks-sourced DataSet, Domo queries the data live from Databricks when the DataFlow runs. Domo checks Databricks-sourced DataSets for updates every 15 minutes using the `lastModified` field returned by Databricks's `DESCRIBE DETAIL` command. If Domo detects an update, it triggers any DataFlows that use that table.
+When a DataFlow uses a Databricks-sourced DataSet, Domo queries the data live from Databricks when the DataFlow runs. Domo checks Databricks-sourced DataSets for updates at the configured freshness interval using the `lastModified` field returned by Databricks's `DESCRIBE DETAIL` command. If Domo detects an update, it triggers any DataFlows that use that table.
+
+**Note:** Change detection via `DESCRIBE DETAIL` applies to tables only. Databricks views do not support this check, so Domo treats views as updated on every freshness check cycle — meaning any DataFlow using a Databricks view will be triggered every interval regardless of whether the underlying data changed.
 </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
## Summary

- Corrects the FAQ entry in `s/article/000005289.mdx` ("How do Databricks-sourced DataSets work?")
- Replaces the inaccurate claim that Domo uses `LAST_ALTERED` from `information_schema.tables` with the accurate description: Domo uses the `lastModified` field from Databricks's `DESCRIBE DETAIL` command

## Why

`information_schema.tables.LAST_ALTERED` in Databricks only updates on DDL/schema changes, not data changes. The actual implementation in `DatabricksEngine.java` (lines 1603–1645) runs `DESCRIBE DETAIL <catalog>.<schema>.<table>` and reads `lastModified`, which reflects actual data modifications. A customer noticed the discrepancy when they couldn't find any `LAST_ALTERED` queries in their `system.query_history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)