### PR TITLE
fix(connector-review): check all Jira comments for approval, not just @-mentioned reviewer

### DIFF
--- a/scripts/connector-review.py
+++ b/scripts/connector-review.py
@@ -326,12 +326,12 @@ def analyze_jira_ticket(jira_id, my_account_id, templates):
             action_type = "publish"
 
     secondary_ids = {a["accountId"] for a in secondary_approvers}
-    known_approver_names = [n.lower() for n in templates.get("known_approvers", [])]
+    arun_account_id = arun_account["accountId"] if arun_account else None
 
     # Check for secondary approval after Arun's comment.
-    # Accepts approvals from: (a) accounts Arun @-mentioned, or (b) anyone in known_approvers.
-    # Also treats a secondary's publish/migration request as an implicit approval — when a
-    # reviewer says "please publish it" they have approved and are escalating to Jared.
+    # Scan ALL comments after Arun's initial @-mention comment — any non-Arun, non-Jared
+    # commenter who uses an approval phrase counts. This handles cases where someone other
+    # than the @-mentioned reviewer verifies the changes (e.g. a teammate steps in).
     secondary_approved = False
     past_arun = arun_comment is None  # if no arun comment, scan all
     for c in comments:
@@ -339,23 +339,22 @@ def analyze_jira_ticket(jira_id, my_account_id, templates):
             if c.get("id") == arun_comment.get("id"):
                 past_arun = True
             continue
-        author = c.get("author", {})
-        author_id = author.get("accountId", "")
-        author_name = author.get("displayName", "").lower()
-        is_known = any(kn in author_name for kn in known_approver_names)
-        if author_id in secondary_ids or is_known:
-            text = extract_text(c.get("body", {})).lower()
-            if any(p in text for p in approval_phrases):
-                secondary_approved = True
-                break
-            if any(p in text for p in publish_phrases):
-                secondary_approved = True
-                action_type = "publish"
-                break
-            if any(p in text for p in migration_phrases):
-                secondary_approved = True
-                action_type = "migration"
-                break
+        author_id = c.get("author", {}).get("accountId", "")
+        # Skip Arun's own follow-on comments and Jared's follow-up/escalation markers
+        if author_id in (arun_account_id, my_account_id):
+            continue
+        text = extract_text(c.get("body", {})).lower()
+        if any(p in text for p in approval_phrases):
+            secondary_approved = True
+            break
+        if any(p in text for p in publish_phrases):
+            secondary_approved = True
+            action_type = "publish"
+            break
+        if any(p in text for p in migration_phrases):
+            secondary_approved = True
+            action_type = "migration"
+            break
 
     # Track follow-ups and escalation posted by Jared
     follow_up_count = 0

--- a/scripts/connector-templates.json
+++ b/scripts/connector-templates.json
@@ -24,11 +24,6 @@
     "marker": "[CONNECTOR-ESCALATION]"
   },
 
-  "known_approvers": [
-    "Nareshkumar Punnam",
-    "Hiren Bhatt"
-  ],
-
   "approval_phrases": [
     "looks good",
     "look good",


### PR DESCRIPTION
## Summary
- Drops the `secondary_ids / known_approvers` filter on the approval-phrase scan. Now any comment after Arun's initial @-mention counts as approval, as long as it's not from Arun or Jared.
- Removes the now-unused `known_approvers` list from `connector-templates.json`.
- Updates the skill doc's **Approval Detection** section to reflect the new behavior.

**Root cause caught:** DOMO-489021 had an approval comment from Ankita Kore ("Verified changes. KB report list looks good to me.") but the designated reviewer was Megha Guralwar. The old logic required the commenter to be the @-mentioned person, so Ankita's approval was silently skipped.

## Test plan
- [ ] Run `python3 scripts/connector-review.py` — dashboard loads without errors
- [ ] Verify tickets where a non-@-mentioned reviewer approved are now detected correctly on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)