### PR TITLE
docs: add v2.11.0 release notes

### DIFF
--- a/releaseNotes/v2.11.0.mdx
+++ b/releaseNotes/v2.11.0.mdx
@@ -1,0 +1,54 @@
+---
+title: "Domo Documentation Hub v2.11.0 Release Notes"
+---
+
+> **⚠️Note on v2.10.0:** The User Impersonation feature that appeared in the v2.10.0 release notes ("Impersonate Users in Domo") was pulled from release before shipping. The article has been removed from the knowledge base and is unpublished until further notice.
+
+Hello everyone!
+
+We're excited to announce that version 2.11.0 of the Domo Documentation Hub is now available! This release brings substantial connector documentation improvements, a major expansion of our multilingual knowledge base, a developer docs cleanup, and several new internal tooling enhancements. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🔌 Connector Documentation Enhancements
+
+The Procore Connector article received a significant expansion this release — the reports section previously listed reports as available without documenting them individually. It now includes a comprehensive table covering 80+ named reports with descriptions, making it much easier for users to identify the right report for their use case. Learn more about the [Procore Connector](https://www.domo.com/docs/s/article/360043435013).
+
+The Smartsheet Writeback Connector article was also updated: the prerequisite section now links to the shared guide for generating a Domo Client ID and Secret instead of repeating those steps inline, and a new step-by-step section walks users through locating their Smartsheet folder ID when using the "Enter Folder ID Manually" option. Learn more about the [Smartsheet Writeback Connector](https://www.domo.com/docs/s/article/360042932514).
+
+The DomoStats Connector article had the Grants report removed — it is no longer available in the product. Several other connector articles received minor title corrections and cleanup: SAP Concur, Shopify, Moz, Encompass REST, Microsoft SQL Server Writeback, Microsoft SharePoint Online Writeback, and Microsoft SharePoint Online P&G Writeback.
+
+Thanks to Arun Raj for the connector documentation work and to jkreitzman for the DomoStats accuracy fix.
+
+### 🌍 Localization Expansion
+
+This release marks a significant step forward in multilingual coverage. Five new articles and several release notes pages are now available in Spanish, French, and German. On the Japanese side, 12 new articles were added — including translations for AI Admin Agent Settings, the Anthropic Admin Connector, Configure Agent Role and Instructions, GitHub Connector, SFTP Connector, and several others covering the 2025 Release 4 and 2026 Release 1 content batches.
+
+Supporting this expansion, the `BetaNote` snippet now exports localized variants for all five supported languages (ES, FR, DE, JA), and a new Localization-Style-Guide.mdx has been published to standardize future localization work across the team.
+
+Thanks to Jared Peterson for the localization infrastructure and Masaaki for the Japanese translations.
+
+### 📹 Video Library Refresh
+
+The Domo Video Library was updated this cycle. A new microlearning video — Domo Webforms DataSet Overview — has been added, covering how to create and manage Webforms DataSets directly in Domo. Several older microlearning videos were removed to keep the library current.
+
+### 🛠 Developer Documentation Cleanup
+
+The AppDB API article had an outdated `Warning` block removed. The block described required fields for filter rules in a way that no longer reflected the product's behavior, and its presence was causing confusion. The surrounding documentation covers these fields accurately without it.
+
+### ⚙️ Internal Tooling Updates
+
+Several new and improved Claude Code skills are available to the documentation team:
+
+- **`/localize`** — A new skill with a full Japanese pipeline, automated quality checkpoints, token usage tracking, and KB style guide integration. Supports ES, FR, DE, and JA workflows.
+- **Connector review: on-hold system** — A new on-hold mechanism allows Jira tickets for indefinitely paused connector PRs to be tracked and managed without cluttering the active review queue.
+- **Release notes skill** — The skill now includes an auto branch/commit/PR step, so approved notes can be published in one workflow without manual git commands.
+- **New Localization-Style-Guide.mdx** — A reference guide for the docs team covering translation standards, formatting rules, and quality expectations across all supported languages.
+
+Thanks to Jared Peterson for building out these workflow automations.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who contributed to this release — Arun Raj, jkreitzman, Masaaki, and Jared Peterson. Your work keeps the knowledge base accurate, accessible, and growing.
+
+If you have questions or feedback, please reach out — we're always happy to help!

--- a/releaseNotesExternal/v2.11.0.mdx
+++ b/releaseNotesExternal/v2.11.0.mdx
@@ -1,0 +1,35 @@
+---
+title: "Domo Documentation Hub v2.11.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.11.0 of the Domo Documentation Hub is now available! This release brings substantial connector documentation improvements, a major expansion of our multilingual knowledge base, and a developer docs cleanup. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🔌 Connector Documentation Enhancements
+
+The Procore Connector article received a significant expansion this release — the reports section previously listed reports as available without documenting them individually. It now includes a comprehensive table covering 80+ named reports with descriptions, making it much easier for users to identify the right report for their use case. Learn more about the [Procore Connector](https://www.domo.com/docs/s/article/360043435013).
+
+The Smartsheet Writeback Connector article was also updated: the prerequisite section now links to the shared guide for generating a Domo Client ID and Secret instead of repeating those steps inline, and a new step-by-step section walks users through locating their Smartsheet folder ID when using the "Enter Folder ID Manually" option. Learn more about the [Smartsheet Writeback Connector](https://www.domo.com/docs/s/article/360042932514).
+
+The DomoStats Connector article had the Grants report removed — it is no longer available in the product. Several other connector articles received minor title corrections and cleanup: SAP Concur, Shopify, Moz, Encompass REST, Microsoft SQL Server Writeback, Microsoft SharePoint Online Writeback, and Microsoft SharePoint Online P&G Writeback.
+
+### 🌍 Localization Expansion
+
+This release marks a significant step forward in multilingual coverage. Five new articles and several release notes pages are now available in Spanish, French, and German. On the Japanese side, 12 new articles were added — including translations for AI Admin Agent Settings, the Anthropic Admin Connector, Configure Agent Role and Instructions, GitHub Connector, SFTP Connector, and several others covering the 2025 Release 4 and 2026 Release 1 content batches.
+
+### 📹 Video Library Refresh
+
+The Domo Video Library was updated this cycle. A new microlearning video — Domo Webforms DataSet Overview — has been added, covering how to create and manage Webforms DataSets directly in Domo. Several older microlearning videos were removed to keep the library current.
+
+### 🛠 Developer Documentation Cleanup
+
+The AppDB API article had an outdated `Warning` block removed. The block described required fields for filter rules in a way that no longer reflected the product's behavior, and its presence was causing confusion. The surrounding documentation covers these fields accurately without it.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who helped make this release possible. Your contributions keep the knowledge base accurate, accessible, and growing.
+
+If you have questions or feedback, please reach out — we're always happy to help!


### PR DESCRIPTION
## Summary
- Adds internal release notes to `releaseNotes/v2.11.0.mdx` (includes INTERNAL ONLY note about User Impersonation being pulled from v2.10.0)
- Adds sanitized external release notes to `releaseNotesExternal/v2.11.0.mdx`

## Test plan
- [ ] Verify both files render correctly on the Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)