### PR TITLE
Add CLDR locale formatting note to Configure Language Settings

### DIFF
--- a/s/article/360043439133.mdx
+++ b/s/article/360043439133.mdx
@@ -56,6 +56,10 @@ Your personal view of Domo now displays in that language.
    <Frame><img alt="confirm personal language.jpg" src="/images/kb/ka0Vq00000010Qz-00N5w00000Ri7BU-0EMVq000000z96P.jpg"/></Frame>
 ### Use European Number Formatting
 
+<Note>
+  **Note:** Domo formats dates and numbers according to the [CLDR international standard](https://www.unicode.org/cldr/cldr-aux/charts/24/summary/) for your locale. You can look up the expected format for your locale at that link.
+</Note>
+
 If you want to use English with European number formatting, use the **English (Netherlands)** setting. Follow the steps below.
 
 <Note>


### PR DESCRIPTION
## Summary

- Adds a Note to the **Use European Number Formatting** section of the Configure Language Settings article explaining that Domo formats dates and numbers according to the CLDR international standard for the user's locale, with a link to the CLDR lookup chart.

## Scope

Only one article updated (`s/article/360043439133.mdx`). No other articles in the repo explicitly discuss locale-based date/number formatting as a product feature — candidates like "Changing the Date Format in Your Chart" and "Time Zone Formatting" cover different concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)