### PR TITLE
fix: restore AppDB filter required-fields warning

### DIFF
--- a/portal/API-Reference/app-framework-apis/AppDB-API.mdx
+++ b/portal/API-Reference/app-framework-apis/AppDB-API.mdx
@@ -1228,6 +1228,26 @@ In this example, any user who belongs to the group with ID `12` or `15` in Domo 
 
 ![Filter Rule](/images/dev/web-assets.domo.com/miyagi/images/product/product-feature-dev-portal-appdbb-security-Filtering.png)
 
+<Warning>
+**All four core fields are required — even when empty.** Omitting any of them causes the upload to fail.
+
+- **Required:** `name`, `applyOn`, `applyTo`, `query`
+- **Optional:** `applyToAll` (default `false`), `limitToOwner` (default `false`)
+
+Minimal example — restrict every user to only their own documents:
+
+```json
+{
+  "name": "mindYaBusiness",
+  "applyOn": ["READ", "UPDATE", "DELETE"],
+  "applyTo": [{ "type": "USER_ID", "values": [] }],
+  "query": {},
+  "applyToAll": true,
+  "limitToOwner": true
+}
+```
+</Warning>
+
 **Filter Rule**
 
 - `name` – The name of the filter rule that you intend to create. This will be used mainly as a description of what you intend the rule to accomplish.


### PR DESCRIPTION
## Summary

- Restores the `<Warning>` block in the Document Level Security Filtering section of `AppDB-API.mdx` that was accidentally removed by commit `2840c56` on Jun 18, 2026
- The warning documents that `name`, `applyOn`, `applyTo`, and `query` are all required on every filter rule — even when empty — and that omitting any of them causes the upload to fail
- This content was originally added in PR #304 and polished in a follow-up commit; the "0618" commit overwrote the file with a version that predated both

## Test plan

- [ ] Confirm the `<Warning>` block renders correctly in the AppDB API docs under the Filter Rule diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)