### PR TITLE
Document branch, GA release, and publishing conventions for agents

### DIFF
--- a/.claude/skills/new-kb-article/SKILL.md
+++ b/.claude/skills/new-kb-article/SKILL.md
@@ -33,10 +33,11 @@ If the feature is brand-new and not yet in the reference, find the closest match
 
 ## Step 3: Gather release information
 
-After the Article Intake Summary is confirmed, ask the following two questions before writing:
+After the Article Intake Summary is confirmed, ask the following questions before writing:
 
 1. **Release status:** What is the release status of the feature(s) covered in this article? For each distinct feature or section, is it GA (generally available) or beta? If mixed, which parts are beta?
 2. **Planned branch cut date:** What is the planned **branch cut date** for this release? This is the internal branch name (NOT the feature release date).
+3. **Feature switch date:** (Ask only if the article is tied to a GA release.) On what date do customers see the feature? This determines the branch name and the base branch (see **Step 8**). Do not try to derive it from the branch cut date; if the user doesn't know it, tell them the article can't be routed to a GA branch until they get it from the PM or release checklist.
 
 ---
 
@@ -124,10 +125,34 @@ python3 -c "import json; json.load(open('docs.json')); print('docs.json is valid
 1. Tell the user the file path of the new MDX article (`s/article/Article-Title-Here.mdx`).
 2. Confirm the article was added to `docs.json` navigation and state where it was placed.
 3. Note any sections left as placeholders (screenshots, specific grant names, etc.) that the user will need to fill in.
+4. State the branch name and PR base branch the article should use, per **Step 8**.
 
 ---
 
-## Step 7: Offer localization
+## Step 8: Branch and PR routing
+
+Tell the user which branch and base branch this article belongs on. Do not create the branch or open the PR unless they ask.
+
+**If the article is not tied to a GA release:** branch `first.last/short-description`, base `main`. It publishes on the normal weekly KB schedule (PR in by Thursday for the following Monday).
+
+**If the article is tied to a GA release:** use the feature switch date collected in Step 3:
+
+- Branch: `first.last/Article-Title-ga-MM-DD-YYYY` (zero-padded numeric date)
+- Base: the GA branch for that date, named with a spelled-out month, such as `release-ga/may-20-2026`
+
+Confirm the GA branch exists before telling the user to target it:
+
+```bash
+git branch -r | grep release-ga
+```
+
+If it doesn't exist, tell the user the Knowledge Base Administrator needs to create it. Do not tell them to base on `main` instead, because that would publish the article before the feature ships.
+
+See `CLAUDE.md` › **Contribution Workflow** for the full convention.
+
+---
+
+## Step 9: Offer localization
 
 After delivering the output above, ask the user:
 

--- a/.claude/skills/revise-submission/SKILL.md
+++ b/.claude/skills/revise-submission/SKILL.md
@@ -36,6 +36,17 @@ If `$ARGUMENTS` names a specific file, revise only that file (confirm it exists 
 
 If there are no qualifying MDX files in the PR, tell the user and stop.
 
+### Check the base branch against the branch name
+
+Using the `headRefName` and `baseRefName` already returned above, verify the PR targets the right base. This is cheap to check here and expensive to catch after merge.
+
+- If `headRefName` contains `-ga-<date>` but `baseRefName` is `main`, flag it: GA-tied content merged to `main` publishes before the feature ships. It should base onto the `release-ga/*` branch for that date (spelled-out month, such as `release-ga/may-20-2026`). Confirm with `git branch -r | grep release-ga`.
+- If `baseRefName` is a `release-ga/*` branch but `headRefName` has no GA date, mention it. Either the branch name is missing its date or the base is wrong.
+
+Report the mismatch and let the user decide whether to retarget the PR. Do not retarget it yourself, and do not let this block the style revision. Continue to Step 2 either way.
+
+See `CLAUDE.md` › **Contribution Workflow** for the convention.
+
 ---
 
 ## Step 2: Get the added/changed text for each file

--- a/.claude/skills/update-kb-article/SKILL.md
+++ b/.claude/skills/update-kb-article/SKILL.md
@@ -284,10 +284,36 @@ Tell the user:
 - What was changed, created, or deleted
 - Any follow-up actions they need to handle manually (e.g., uploading new image assets, updating absolute links on the live Salesforce support site)
 - Any files that were intentionally left unchanged and why
+- The branch and PR base branch the change belongs on, per **Step 8**
 
 ---
 
-## Step 8: Offer localization
+## Step 8: Branch and PR routing
+
+If the user is already on a working branch, verify it matches the convention and that its base is correct. Otherwise, tell them what to use. Do not create the branch or open the PR unless they ask.
+
+**Routine updates:** branch `first.last/short-description`, base `main`. Publishes on the normal weekly KB schedule (PR in by Thursday for the following Monday).
+
+**Updates documenting a change that ships with a GA release:** the article must not go live before the feature. If the change is tied to a release and you don't already know the **feature switch date** (the date customers see the feature), ask for it. Never derive it from the product branch cut date.
+
+- Branch: `first.last/short-description-ga-MM-DD-YYYY` (zero-padded numeric date)
+- Base: the GA branch for that date, named with a spelled-out month, such as `release-ga/may-20-2026`
+
+Confirm the GA branch exists before telling the user to target it:
+
+```bash
+git branch -r | grep release-ga
+```
+
+If it doesn't exist, tell the user the Knowledge Base Administrator needs to create it. Do not fall back to `main`.
+
+If the user is on a branch whose name contains `-ga-<date>` but whose PR bases onto `main`, flag it: the change would publish ahead of the feature.
+
+See `CLAUDE.md` › **Contribution Workflow** for the full convention.
+
+---
+
+## Step 9: Offer localization
 
 After delivering the output above, ask the user:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,9 @@ All navigation is defined in **`docs.json`** (large file, \~307KB). The schema i
 
 ## MDX Content Conventions
 
-All articles use YAML frontmatter with at minimum a `title` field.
+All articles require two YAML frontmatter fields: `title` and `excerpt` (a single sentence summarizing what the article covers, placed directly below `title`). Never use `description` in place of `excerpt`, because Mintlify renders `description` on the published page, which duplicates the Intro section, while `excerpt` stays invisible and serves as repo-level metadata for search and AI context. See `Domo-KB-Style-Guide.mdx` › **Excerpt**.
+
+Images and video clips must be committed to `images/kb/` on the same branch before an article references them.
 
 Key Mintlify components in use:
 
@@ -69,6 +71,77 @@ Domo releases monthly. Branches are named by the date the branch is cut. From br
 - Feature release (feature switches enabled, customers see new features) is \~1 week after code ships
 
 Internally, releases are always identified by the **branch cut date** (the branch name). Customers and client-facing teams only care about when features appear in their environments, so they talk in terms of the feature release date — PMs translate between the two. For tracking feature availability and mapping KB articles to releases, always use the **branch cut date** as the canonical identifier.
+
+This is the **product** release cadence. The KB publishes on its own weekly schedule (see **KB Publishing Cadence** below). The two only intersect for GA-tied documentation.
+
+## Contribution Workflow
+
+The authoritative source is the [KB Contribution App](https://domo.domo.com/app-studio/649552668/pages/1393071293) (access via Jared Peterson, the Knowledge Base Administrator). Agents can't reach it, so the conventions that affect repo work are recorded here.
+
+### Branch Naming
+
+Standard content work, such as a new article, an edit, or an image swap:
+
+```
+first.last/short-description
+```
+
+Example: `jared.peterson/pricing-update`
+
+Work tied to a **GA release** with a specific feature switch date:
+
+```
+first.last/article-title-ga-MM-DD-YYYY
+```
+
+Example: `jared.peterson/XTM-Connector-ga-05-20-2026`
+
+Use a zero-padded numeric `MM-DD-YYYY` date. The date is the **feature switch date** (when customers see the feature), not the product branch cut date.
+
+Never derive the feature switch date from the branch cut date. Ask the user, the PM, or the release checklist for it. The product cadence gives a rough interval, not a date you can compute reliably.
+
+### GA Release Workflow
+
+GA-tied documentation must go live in sync with the feature, never before. It does not go to `main` on the normal schedule:
+
+- A dedicated GA branch exists for each release date, using a **spelled-out month**: `release-ga/may-20-2026`, `release-ga/sept-23-2026`
+- GA PRs base onto that `release-ga/*` branch, not `main`
+- They are reviewed and approved normally, then held; the KB Administrator merges the GA branch into `main` on the feature switch date, outside the normal release schedule
+- This mirrors how release-notes branches work: changes queue in the GA branch, get validated together, and ship as one merge
+
+Before opening a GA PR, confirm the target branch exists:
+
+```bash
+git branch -r | grep release-ga
+```
+
+If the branch for that date doesn't exist yet, say so, since the KB Administrator creates it. Don't fall back to basing on `main`.
+
+Signal GA intent in **both** the branch name and the PR description so the PR gets routed to the right base branch.
+
+### Pull Requests
+
+- Base: `main`, or the appropriate `release-ga/*` branch for GA work
+- One topic per PR. Never mix unrelated updates; smaller PRs are approved faster
+- Clear title and description
+- Assign to the Knowledge Base Administrator (Jared Peterson) for review
+- If changes are requested, commit to the same branch, and the PR updates automatically
+
+Commit messages: present tense, short, describing the change and not the tool. `Add XTM-Connector article`, `Update pricing section`, `Clarify setup steps`.
+
+### KB Publishing Cadence
+
+Merging to `main` does not publish immediately. Content is held for the next scheduled release:
+
+| When | What happens |
+| -------------------- | ----------------------------------------------------------------------------- |
+| Thursday | Deadline to submit a PR for the following Monday's release |
+| Friday, early PM | The release is cut |
+| Monday morning | Enablement switches the release branch via an EC ticket, then Mintlify rebuilds and content goes live |
+
+Mid-week releases are possible for urgent fixes or specific customer asks, but the user must request one from the Knowledge Base Administrator.
+
+When telling a user their change is done, be accurate about this: merged is not live. If a deadline is relevant (e.g. it's Friday and they expect Monday publication), say so.
 
 ## Finding Existing Articles
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ mintlify dev
 
 ## Deployment
 
-- **`main`** — merges auto-deploy to production via the Mintlify GitHub App.
+Merging does not publish. Once your changes are approved and merged into `main`, they are held until the next scheduled release, at which point Mintlify rebuilds the site and the updated content goes live.
+
+- **Release schedule:** to be included in the following Monday's release, submit your PR by Thursday. The release is cut Friday early afternoon. Monday morning, the Enablement team switches over the release branch via an EC ticket; after that changeover completes, Mintlify rebuilds and the content is live.
+- **Mid-week releases:** in certain circumstances, such as a specific customer ask or a highly visible fix, a release can be cut mid-week. Contact the Knowledge Base Administrator to request one.
 - **`release/**`** — pushes to release branches create a Mintlify preview via `.github/workflows/mint-preview.yml`. Preview URL is posted to any open PR whose head is the release branch.
 - **Any PR** — Mintlify's GitHub App posts a preview link in the PR's Checks tab.
 


### PR DESCRIPTION
## What and why

The KB contribution workflow (branch naming, the GA release process, and the publishing cadence) is documented in the [KB Contribution App](https://domo.domo.com/app-studio/649552668/pages/1393071293). AI agents working in this repo can't reach the app, so they had no way to know any of it. Nothing in `CLAUDE.md`, the skills, or the README described the `first.last/short-description` format, the `release-ga/*` workflow, or the fact that merging to `main` doesn't publish.

This records those conventions in the AI-facing files, sourced from the contributor guide (Updated June 2026).

## Changes

**`CLAUDE.md`**, new **Contribution Workflow** section:
- Branch naming: `first.last/short-description`, and the GA form `first.last/article-title-ga-MM-DD-YYYY`
- GA release workflow: base onto the `release-ga/<spelled-month>-DD-YYYY` branch, held and merged to `main` on the feature switch date, with an existence check for the target branch and an explicit instruction not to fall back to `main`
- PR conventions (one topic, assign to the KB Administrator) and commit-message style
- **KB Publishing Cadence** table: Thursday submission deadline, Friday cut, Monday EC-ticket changeover, then live, plus the mid-week release option

Also corrected two smaller things in the same file. The frontmatter note said articles need "at minimum a `title` field", but `excerpt` is required and `description` is prohibited, which the style guide already covers. And added that images must be committed to `images/kb/` before an article references them.

**`README.md`**: corrected the Deployment section. It claimed merges to `main` "auto-deploy to production via the Mintlify GitHub App", which contradicts the contributor guide, since content is held until the next scheduled release. Now describes the real schedule and the mid-week release option. Kept non-technical, and left the GA workflow out since the app covers that for human contributors.

**`new-kb-article`, `update-kb-article`**: both now collect the feature switch date when work is GA-tied and route the branch name and PR base accordingly. `new-kb-article` was already asking for the branch cut date and doing nothing with it. Also fixes duplicate Step 7 numbering in `new-kb-article`.

**`revise-submission`**: Step 1 already fetches `baseRefName`, so it now flags PRs whose branch name and base branch disagree about GA status. A `-ga-<date>` branch based on `main` would publish ahead of the feature. Reports only, doesn't retarget, doesn't block the style pass.

## Notes for review

- The GA date format is zero-padded `MM-DD-YYYY` per the guide's example (`jared.peterson/XTM-Connector-ga-05-20-2026`), matching the live `release-ga/*` branches. The guide's format string reads `ga-mo.-day-yr`, which its own example contradicts, so I followed the example.
- Docs-only change. No article content, navigation, or workflow files touched.
- Separately: the guide notes `legacy-icon-*` for pre-refresh UI surfaces (release notes, Workbench) vs `icon-*` elsewhere. `CLAUDE.md` doesn't mention the legacy font. Happy to add it here or in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)