### PR TITLE
Fix Warning By Restoring Japanese Heat Map Article

### DIFF
--- a/ja/s/article/360042924634.mdx
+++ b/ja/s/article/360042924634.mdx
@@ -1,0 +1,69 @@
+---
+title: "ヒートマップ"
+excerpt: "2つのカテゴリ軸間で長方形の色を変化させてデータの関係とホットスポットを強調表示する、ヒートマップを作成します。"
+---
+
+## はじめに
+
+ヒートマップはX軸とY軸の両方にカテゴリデータを含む特殊なグラフです。長方形の色は、特定のデータポイントが指定されたデータ範囲にどのように当てはまるかによって異なります。ヒートマップを使用すると、データカテゴリ間の関係を視覚化し、アクティビティのホットスポットやトレンドに注目することができます。
+
+---
+
+## ヒートマップへのデータの追加
+
+ヒートマップには、データソースから3つのデータ列または行が必要です。そのうち2つはカテゴリデータを含み、もう1つは各カテゴリペアの値を含みます。系列データは表示されません。各カテゴリペアの値は、特定の範囲に対応する色の濃淡によってマップ上に表示されます。範囲はDataSet内の値の分布に基づいて自動的に決定されますが、**グラフのプロパティ > 範囲** で独自の範囲を指定することもできます。範囲は凡例によって表示され、グラフの下に自動的に含まれます。
+
+値、カテゴリ、系列データの詳細については、「[グラフデータを理解する](/s/article/360043428693 "Understanding Chart Data")」を参照してください。
+
+Analyzerでは、ヒートマップのデータが含まれる列を選択します。データ列の選択方法の詳細については、「[DataSetの列をグラフに適用する](/s/article/360043428713 "Applying DataSet Columns to Your Chart")」を参照してください。
+
+Analyzerでのグラフのフォーマットの詳細については、「[KPIカードの作成 パート2: Analyzer](/s/topic/0TO5w000000ZaoUGAS "KPI Card Building Part 2: The Card Builder")」を参照してください。
+
+次のグラフは、一般的な列ベースのスプレッドシートのデータがヒートマップに変換される方法を示しています。
+
+<Frame><img alt="heatmap_spreadsheet_example_new.png" src="/images/kb/ka0Vq0000003isX-00N5w00000Ri7BU-0EM5w000005vP9A.png"/></Frame>
+
+## ヒートマップをカスタマイズする
+
+ヒートマップの外観は、**グラフのプロパティ** を編集してカスタマイズできます。すべてのグラフのプロパティの詳細については、「[グラフのプロパティ](/s/topic/0TO5w000000ZaodGAC "Chart Properties")」を参照してください。
+
+**ビデオ - ヒートマップの作成とカスタマイズ**
+
+<iframe allowfullscreen="allowfullscreen" frameborder="0" height="315" src="//www.youtube-nocookie.com/embed/0WOEhWTDG30" width="560"></iframe>
+
+ヒートマップ固有のプロパティは以下のとおりです。サムネイル画像をクリックすると、より大きな画像が表示されます。
+
+<table border="1" cellpadding="1" cellspacing="1" data-aura-rendered-by="33:206;a"><thead><tr><th colspan="1" rowspan="1"><p> プロパティ </p></th><th colspan="1" rowspan="1"><p> 説明 </p></th><th colspan="1" rowspan="1"><p> 例 </p></th></tr></thead><tbody><tr><td colspan="1" rowspan="1"><p> 一般 &gt; テーマ </p></td><td colspan="1" rowspan="1"><p> ヒートマップのカラーテーマを変更できます。色の設定の詳細については、「<a href="/s/article/360043429653" target="_self" title="Changing the Default Colors in Your Chart"> グラフのデフォルトの色を変更する </a>」を参照してください。 </p></td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"><p> 一般 &gt; 内側の余白 </p></td><td colspan="1" rowspan="1"><p> ヒートマップのセルを区切るスペースの量をピクセル単位で設定できます。例では、余白を <code> 8 </code> に設定したヒートマップを示しています。 </p></td><td colspan="1" rowspan="1"><img alt="heatmap_margins.png" src="/images/kb/ka05w00000123lV-00N5w00000Ri7BU-0EM5w000005vP20.png"/></td></tr><tr><td colspan="1" rowspan="1"><p> 一般 &gt; バランスの取れた分布 </p></td><td colspan="1" rowspan="1"><p> マップとヒートマップを調整して、各範囲内に均衡した数の項目を含めます。データに極端な外れ値が含まれている場合に、各範囲に値を分散させるのに役立ちます。 </p><p> 右側のスクリーンショットのペアは、<b> バランスの取れた分布 </b> の動作を示しています。これらのヒートマップでは、ほとんどのマスの値は2から100の範囲です。タンパ市のEastern diamondbacksは214という外れ値です。上のマップでは <b> バランスの取れた分布 </b> がオンになっていないため、データの歪んだバージョンが表示されます。Eastern diamondbacks/タンパは濃く表示され、他のすべての地域は薄く表示されます。下のマップでは、ユーザーが <b> バランスの取れた分布 </b> をオンにしているため、Eastern diamondbacks/タンパは次に高い値のマスと同じ範囲にグループ化されます。 </p></td><td colspan="1" rowspan="1"><p><img alt="heatmap_balanced_distribution_off.png" src="/images/kb/ka0Vq0000003isX-00N5w00000Ri7BU-0EM5w000005vP90.png"/></p><p><img alt="heatmap_balanced_distribution_on.png" src="/images/kb/ka0Vq0000003isX-00N5w00000Ri7BU-0EM5w000005vP91.png"/></p></td></tr><tr><td colspan="1" rowspan="1"><p> 一般 &gt; 最大値を上書き </p></td><td colspan="1" rowspan="1"><p> マップまたはヒートマップの最大値を指定できます。 </p><p> デフォルトでは、Domoはデータセット内の最も高い値を最大値として使用します。ただし、このプロパティを設定することでこの値を上書きできます。 </p></td><td colspan="1" rowspan="1"> — <br/></td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 表示 </td><td colspan="1" rowspan="1"> 選択すると、マップは中間点の上下に2セットのカラー範囲を持つ発散マップとして表示されます。 </td><td colspan="1" rowspan="1"><img alt="HeatMap_No_Midpoint.png" src="/images/kb/ka0Vq0000003isX-00N5w00000Ri7BU-0EM5w000005vP9B.png"/></td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 範囲数 </td><td colspan="1" rowspan="1"> 中間点の上または下に表示される範囲の数です（最大5）。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 中間点の値の種類 </td><td colspan="1" rowspan="1"> 中間点として使用する種類または値です。デフォルト値は中央値です。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 中間点の値 </td><td colspan="1" rowspan="1"> 値の種類が「手動」に設定されている場合に中間点として使用される値です。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 中間点の範囲を表示 </td><td colspan="1" rowspan="1"> 設定すると、凡例とグラフに中間点の値の範囲が表示されます。 </td><td colspan="1" rowspan="1"><img alt="HeatMap_MidPoint.png" src="/images/kb/ka0Vq0000003isX-00N5w00000Ri7BU-0EM5w000005vP93.png"/></td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 中間点の範囲の色 </td><td colspan="1" rowspan="1"> 中間点を表す範囲に使用する色です。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 上部カラーテーマ </td><td colspan="1" rowspan="1"> 中間点より上の範囲に使用する色です。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"> 発散 &gt; 下部カラーテーマ </td><td colspan="1" rowspan="1"> 中間点より下の色に使用するカラーテーマです。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"><p> 範囲 &gt; ゼロをデータなしとして表示 </p></td><td colspan="1" rowspan="1"><p> ヒートマップで値が0のマスを、データのないマスと同じグレー色で表示するかどうかを決定します。 </p></td><td colspan="1" rowspan="1"> — <br/></td></tr><tr><td colspan="1" rowspan="1"> 範囲 &gt; 範囲 <em> X </em> の最大値 </td><td colspan="1" rowspan="1"> 指定した範囲の最大値を設定できます。詳細については、次のセクションを参照してください。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"> 範囲 &gt; 範囲 <em> X </em> の最小値 </td><td colspan="1" rowspan="1"> 指定した範囲の最小値を設定できます。詳細については、次のセクションを参照してください。 </td><td colspan="1" rowspan="1"> — </td></tr><tr><td colspan="1" rowspan="1"> 範囲 &gt; 範囲 <em> X </em> の色 </td><td colspan="1" rowspan="1"> 指定した範囲の色を選択できます。詳細については、次のセクションを参照してください。 </td><td colspan="1" rowspan="1"> — </td></tr></tbody></table>
+
+### カスタム範囲を設定する
+
+ヒートマップを作成すると、Domoは範囲の値を自動的に決定します。また、**テーマ** の **グラフのプロパティ** で選択したテーマに基づいてすべての色を設定します。必要に応じて、最小値と最大値を指定し、各範囲の色を選択することでカスタム範囲を設定できます。ヒートマップでは最大9つの範囲をカスタマイズできます。
+
+たとえば、次のスクリーンショットは、Domoによって範囲と色が自動的に決定されたヒートマップを示しています。
+
+<Frame><img alt="heatmap_ranges_before.png" src="/images/kb/ka0Vq0000003isX-00N5w00000Ri7BU-0EM5w000005vP92.png"/></Frame>
+
+カード作成者は、より多くの色があればカードの解釈が容易になると判断しました。また、自動的に決定された範囲を使用する代わりに、範囲を手動で設定したいと考えています。そこで、次のように5つの範囲を設定します。
+
+* 範囲1 — 最小値1、最大値20、色を青に設定
+* 範囲2 — 最小値21、最大値40、色を緑に設定
+* 範囲3 — 最小値41、最大値60、色を黄色に設定
+* 範囲4 — 最小値61、最大値80、色をオレンジに設定
+* 範囲5 — 最小値81、最大値100、色を赤に設定
+
+作成されたヒートマップは次のように表示されます。
+
+<Frame><img alt="heatmap_ranges_after.png" src="/images/kb/ka05w00000123lV-00N5w00000Ri7BU-0EM5w000005vP1w.png"/></Frame>
+
+**ヒートマップにカスタム範囲を設定するには、次の手順を実行します。**
+
+1. ゲージのAnalyzerを開きます。
+2. **グラフのプロパティ** で、**範囲** をクリックします。
+3. **範囲1の最小値** フィールドに最小値を入力します。
+
+   この値が最初の範囲の最小値になります。
+4. **範囲1の最大値** フィールドに最大値を入力します。
+
+   この値が最初の範囲の最大値になります。
+5. **範囲1の色** の横にあるメニューをクリックし、範囲の色を選択します。
+6. （オプション）必要に応じて新しい範囲を追加します。

--- a/tracking/localize-token-usage.csv
+++ b/tracking/localize-token-usage.csv
@@ -3,3 +3,4 @@ date,run_by,localized_article,languages_translated,tokens_estimated
 2026-07-01,Jared Peterson,000004968.mdx,ja,37000
 2026-07-26,brycewc,360043433813.mdx,ja,95000
 2026-07-28,Jared Peterson,360043433813.mdx,ja,75000
+2026-08-06,Bradley Turek,360042924634.mdx,ja,20000


### PR DESCRIPTION
## Summary

- Restores `ja/s/article/360042924634.mdx` (Japanese Heat Map article), which was referenced in `docs.json` navigation but did not exist, causing a `mintlify dev` build warning
- File is assumed to have existed in a previous iteration of the documentation; the Japanese localization was recreated from the English source article

## Test plan

- [x] Confirm `mintlify dev` no longer warns about `"ja/s/article/360042924634"` being referenced but missing
- [x] Spot-check the Heat Map page renders correctly in the Japanese documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)