### PR TITLE
Fix DomoEmbed React import warning; add live example to style guide

### DIFF
--- a/Domo-KB-Style-Guide.mdx
+++ b/Domo-KB-Style-Guide.mdx
@@ -3,6 +3,8 @@ title: "Domo KB Style Guide"
 excerpt: "Standards and conventions for writing clear, consistent Domo Knowledge Base documentation."
 ---
 
+import { DomoEmbed } from "/snippets/DomoEmbed.mdx";
+
 ## Intro
 
 This style guide provides guidelines for producing Domo Knowledge Base documentation that is clear and consistent. When a specific instance is not addressed within this guide, refer to the following third-party references:
@@ -401,6 +403,10 @@ Three props are available:
 | `initialHeight` | No       | `"600"`  | Starting height in pixels before auto-resize fires. |
 
 <Note>**Note:** The Domo instance that hosts the embed must allow your documentation domain in its embed allowlist. If the iframe appears blank, check the source instance's CSP / embed allowlist settings.</Note>
+
+### Live Example
+
+<DomoEmbed src="https://embed.domo.com/cards/G8mM0" width="600" initialHeight="600" />
 
 ## Callouts
 

--- a/Domo-KB-Style-Guide.mdx
+++ b/Domo-KB-Style-Guide.mdx
@@ -408,6 +408,8 @@ Three props are available:
 
 <DomoEmbed src="https://embed.domo.com/cards/G8mM0" width="600" initialHeight="600" />
 
+Source card: [modocorp.domo.com/kpis/details/1429774452](https://modocorp.domo.com/kpis/details/1429774452)
+
 ## Callouts
 
 Use React callout elements for notes, warnings, and tips — not plain text or HTML. Always bold the label and its colon, for example `**Note:**`.

--- a/snippets/DomoEmbed.mdx
+++ b/snippets/DomoEmbed.mdx
@@ -31,6 +31,12 @@
 
   NOTE: The embed URL must come from a Domo instance that allows embedding on this domain.
   If the iframe appears blank, check the source instance's CSP / embed allowlist settings.
+
+  REACT GLOBALS
+  -------------
+  React.useRef and React.useEffect are called without an import because Mintlify's MDX
+  runtime provides React as a global. Importing from "react" triggers a build warning:
+  "Invalid import path react — only local imports are supported." Do not add the import back.
 */}
 
 export const DomoEmbed = ({ src, width = "100%", initialHeight = "600" }) => {

--- a/snippets/DomoEmbed.mdx
+++ b/snippets/DomoEmbed.mdx
@@ -33,12 +33,10 @@
   If the iframe appears blank, check the source instance's CSP / embed allowlist settings.
 */}
 
-import { useEffect, useRef } from "react";
-
 export const DomoEmbed = ({ src, width = "100%", initialHeight = "600" }) => {
-  const iframeRef = useRef(null);
+  const iframeRef = React.useRef(null);
 
-  useEffect(() => {
+  React.useEffect(() => {
     function handleMessage(event) {
       if (
         iframeRef.current &&


### PR DESCRIPTION
## Summary

- Removes `import { useRef, useEffect } from "react"` from `snippets/DomoEmbed.mdx`, which caused a `mintlify dev` build warning: _"Invalid import path react — only local imports are supported"_
- Replaces with `React.useRef` / `React.useEffect`, which are available as globals in Mintlify's MDX runtime
- Adds a comment in the snippet explaining why there is no import, so a future contributor doesn't add it back
- Adds a live `<DomoEmbed>` example to the **Embedded Domo Content** section of the style guide so contributors can see the component in action
<img width="804" height="778" alt="image" src="https://github.com/user-attachments/assets/ef7b9019-c29a-43e3-8111-c572bdd919f1" />


## Test plan

- [x] Confirm `mintlify dev` no longer warns about `Invalid import path react in /snippets/DomoEmbed.mdx`
- [x] Confirm the live example in the style guide renders the embedded card at `/Domo-KB-Style-Guide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)