### PR TITLE
docs: reconcile App Broadcasting docs with shipped code (DOMO-490337)

### DIFF
--- a/portal/Apps/App-Framework/Guides/broadcasting.mdx
+++ b/portal/Apps/App-Framework/Guides/broadcasting.mdx
@@ -89,7 +89,7 @@ A **sticky** message is retained by the bus. When a new subscriber joins a stick
 
 ```javascript
 // Publisher: send sticky state
-domo.broadcastState('config:theme', { mode: 'dark', accent: '#4A90D9' });
+domo.broadcast('config:theme', { mode: 'dark', accent: '#4A90D9' }, { sticky: true });
 
 // Subscriber (mounts later): receives the last value immediately
 domo.onBroadcast('config:theme', (msg) => {
@@ -104,8 +104,8 @@ Use sticky messages for **state** that late-mounting apps need (theme, selected 
 Apps declare their broadcast channels in `manifest.json`. Declarations serve three purposes:
 
 1. **Discoverability** — The App Store and wiring UIs show what an app publishes and subscribes to
-2. **DevTools validation** — The broadcasting inspector warns when an app uses undeclared channels
-3. **Runtime enforcement** — In production, the host rejects messages on undeclared channels
+2. **Pro Code Editor** — Broadcasting on an undeclared channel logs a `console.warn()`
+3. **Domo page** — Broadcasting on an undeclared channel throws an error
 
 ```json
 {
@@ -143,11 +143,17 @@ The host stamps every message with the publishing app's `sourceAppId`. This valu
 
 ### Rate limiting
 
-Each app instance is limited to **100 messages per second** (configurable by instance admins). Messages exceeding this limit are rejected, and the SDK surfaces an error.
+Each app is limited to **100 messages per second** (configurable by instance admins). Messages exceeding this limit are rejected, and the SDK surfaces an error.
 
 ### Payload size
 
 Each message payload is capped at **64 KB** when serialized. Oversized payloads are rejected client-side by the SDK before reaching the bus.
+
+### Duplicate filtering
+
+The bus tracks the last published payload for each channel and drops messages whose serialized payload is an exact match of the previous value. This prevents redundant subscriber calls when the same state is published repeatedly (for example, clicking the same row twice).
+
+If you need to force a re-delivery of the same value — for example, to re-trigger a side effect — include a sequence number or timestamp in the payload.
 
 ### Page-scoped isolation
 
@@ -196,11 +202,11 @@ The bus exists only within a single page load. There is no cross-page communicat
 import domo from 'ryuu.js';
 
 function onRowClick(row) {
-  domo.broadcastState('selection:changed', {
+  domo.broadcast('selection:changed', {
     id: row.id,
     name: row.name,
     region: row.region
-  });
+  }, { sticky: true });
 }
 ```
 

--- a/portal/Apps/App-Framework/Guides/broadcasting.mdx
+++ b/portal/Apps/App-Framework/Guides/broadcasting.mdx
@@ -3,7 +3,7 @@ title: App Broadcasting
 description: Enable real-time communication between Custom Apps on the same page using a host-mediated pub/sub message bus.
 ---
 
-App Broadcasting lets Custom Apps on the same Domo page exchange named messages in real time. One app publishes a message to a **topic**; any app subscribed to that topic receives it instantly. The system is built on a host-mediated pub/sub bus — apps never communicate directly with each other.
+App Broadcasting lets Custom Apps on the same Domo page exchange named messages in real time. One app publishes a message to a **channel**; any app subscribed to that channel receives it instantly. The system is built on a host-mediated pub/sub bus — apps never communicate directly with each other.
 
 <Note>
 **Note:** App Broadcasting requires the `app-broadcasting` feature switch to be enabled on your instance. When the switch is off, all SDK methods are safe no-ops.
@@ -17,8 +17,8 @@ Use App Broadcasting when your apps need **free-form, real-time coordination** t
 | --- | --- | --- |
 | Page filters | Shared filter state across all cards | Coarse — only filter shapes; clears on first registration |
 | Page variables | Shared key-value state | Limited to primitive values; no event signaling |
-| `requestAppDataUpdate` | Simple one-way notifications | No topic routing; no sticky replay; no type safety |
-| **App Broadcasting** | Typed, topic-based pub/sub with sticky replay | Scoped to a single page; cleared on navigation |
+| `requestAppDataUpdate` | Simple one-way notifications | No channel routing; no sticky replay; no type safety |
+| **App Broadcasting** | Typed, channel-based pub/sub with sticky replay | Scoped to a single page; cleared on navigation |
 
 Choose broadcasting when you need:
 
@@ -53,20 +53,20 @@ Key architectural properties:
 
 ## Core concepts
 
-### Topics
+### Channels
 
-A **topic** is a named string that identifies a message channel. Apps publish to and subscribe on topics.
+A **channel** is a named string that apps publish to and subscribe on.
 
 ```javascript
 domo.broadcast('selection:changed', { rowId: 42 });
 domo.onBroadcast('selection:changed', (msg) => { /* ... */ });
 ```
 
-Topic naming conventions:
+Channel naming conventions:
 
 - Use `namespace:event` format (e.g., `filter:region`, `chart:hover`, `config:theme`)
-- Topics are exact strings — no wildcards
-- Topics starting with `domo:` are **reserved** for system events and cannot be used by apps
+- Channels are exact strings — no wildcards
+- Channels starting with `domo:` are **reserved** for system events and cannot be used by apps
 
 ### Messages
 
@@ -74,7 +74,7 @@ Every delivered message has this shape:
 
 ```typescript
 interface BroadcastMessage {
-  topic: string;       // The topic this message was published to
+  channel: string;     // The channel this message was published to
   payload: unknown;    // The data sent by the publisher
   sourceAppId: string; // Host-stamped ID of the publishing app instance
   timestamp: number;   // Host-assigned timestamp (ms since epoch)
@@ -85,7 +85,7 @@ The `sourceAppId` is stamped by the host and cannot be spoofed. Use it to identi
 
 ### Sticky messages
 
-A **sticky** message is retained by the bus. When a new subscriber joins a sticky topic, it immediately receives the last published value — even if that value was published before the subscriber existed.
+A **sticky** message is retained by the bus. When a new subscriber joins a sticky channel, it immediately receives the last published value — even if that value was published before the subscriber existed.
 
 ```javascript
 // Publisher: send sticky state
@@ -104,8 +104,8 @@ Use sticky messages for **state** that late-mounting apps need (theme, selected 
 Apps declare their broadcast channels in `manifest.json`. Declarations serve three purposes:
 
 1. **Discoverability** — The App Store and wiring UIs show what an app publishes and subscribes to
-2. **DevTools validation** — The broadcasting inspector warns when an app uses undeclared topics
-3. **Runtime enforcement** — In production, the host rejects messages on undeclared topics
+2. **DevTools validation** — The broadcasting inspector warns when an app uses undeclared channels
+3. **Runtime enforcement** — In production, the host rejects messages on undeclared channels
 
 ```json
 {
@@ -135,7 +135,7 @@ App Broadcasting enforces several security primitives at the host level:
 
 ### Reserved namespace
 
-Topic names starting with `domo:` are reserved for host-emitted system events. The SDK rejects these client-side before any message is sent, and the host rejects them server-side as a defense-in-depth measure.
+Channel names starting with `domo:` are reserved for host-emitted system events. The SDK rejects these client-side before any message is sent, and the host rejects them server-side as a defense-in-depth measure.
 
 ### Source identity
 
@@ -159,20 +159,20 @@ The bus exists only within a single page load. There is no cross-page communicat
 | --- | --- | --- | --- |
 | Data shape | Any serializable value (up to 64 KB) | Primitive values | Filter objects |
 | Persistence | Page load only | Saved with page | Saved with page |
-| Late-subscriber replay | Yes (sticky topics) | Yes (always current) | Yes (current state) |
-| Multiple channels | Yes (unlimited topics) | Yes (named variables) | Single filter set |
+| Late-subscriber replay | Yes (sticky channels) | Yes (always current) | Yes (current state) |
+| Multiple channels | Yes (unlimited channels) | Yes (named variables) | Single filter set |
 | Source identity | Yes (`sourceAppId`) | No | No |
 | Event semantics | Pub/sub (fire and forget) | State (always last value) | State |
 | Cross-page | No | Yes | Yes |
 
-**Rule of thumb:** Use variables or filters when you need state that persists across navigation. Use broadcasting when you need real-time, topic-based coordination within a single page session.
+**Rule of thumb:** Use variables or filters when you need state that persists across navigation. Use broadcasting when you need real-time, channel-based coordination within a single page session.
 
 ## Lifecycle
 
 1. **Page loads** — The bus is created (empty, no subscriptions)
-2. **Apps mount** — Each app subscribes to its declared topics via `domo.onBroadcast()`
+2. **Apps mount** — Each app subscribes to its declared channels via `domo.onBroadcast()`
 3. **Messages flow** — Apps publish and receive messages in real time
-4. **Sticky replay** — Late-mounting apps receive the last sticky value for each topic they subscribe to
+4. **Sticky replay** — Late-mounting apps receive the last sticky value for each channel they subscribe to
 5. **Page navigates** — The bus is destroyed; all subscriptions and sticky state are cleared
 
 ## Quick start

--- a/portal/Apps/App-Framework/Guides/broadcasting.mdx
+++ b/portal/Apps/App-Framework/Guides/broadcasting.mdx
@@ -1,55 +1,70 @@
 ---
 title: App Broadcasting
-description: Enable real-time communication between Custom Apps on the same page using a host-mediated pub/sub message bus.
+description: Real-time messaging between Custom Apps on the same Domo page, using a host-mediated pub/sub bus.
 ---
 
-App Broadcasting lets Custom Apps on the same Domo page exchange named messages in real time. One app publishes a message to a **channel**; any app subscribed to that channel receives it instantly. The system is built on a host-mediated pub/sub bus — apps never communicate directly with each other.
+App Broadcasting lets Custom Apps on the same Domo page send each other named messages in real time. One app **publishes** a message to a **channel**; every other app that **subscribes** to that channel receives it. Apps never talk to each other directly — the Domo page (the host) sits in the middle and routes every message.
 
 <Note>
-**Note:** App Broadcasting requires the `app-broadcasting` feature switch to be enabled on your instance. When the switch is off, all SDK methods are safe no-ops.
+**Note:** App Broadcasting requires the `app-broadcasting` feature switch. While it is off, publishing does nothing and no messages are delivered — the host answers each publish with a `FEATURE_DISABLED` notice that the SDK writes to the browser console. Contact your Domo administrator to enable it.
 </Note>
 
 ## When to use broadcasting
 
-Use App Broadcasting when your apps need **free-form, real-time coordination** that goes beyond what page filters or variables provide:
+Broadcasting is for **free-form, real-time coordination** between apps — the kind of signalling that page filters and variables aren't built for.
 
-| Mechanism | Best for | Limitations |
-| --- | --- | --- |
-| Page filters | Shared filter state across all cards | Coarse — only filter shapes; clears on first registration |
-| Page variables | Shared key-value state | Limited to primitive values; no event signaling |
-| `requestAppDataUpdate` | Simple one-way notifications | No channel routing; no sticky replay; no type safety |
-| **App Broadcasting** | Typed, channel-based pub/sub with sticky replay | Scoped to a single page; cleared on navigation |
+| Mechanism              | Best for                                   | Trade-offs                                       |
+| ---------------------- | ------------------------------------------ | ------------------------------------------------ |
+| Page filters           | Shared filter state across all cards       | Filter shapes only; clears on first registration |
+| Page variables         | Shared key-value state                     | Primitive values; no event signalling            |
+| `requestAppDataUpdate` | Simple one-way notifications               | No channels; no source identity                  |
+| **App Broadcasting**   | Channel-based pub/sub with source identity | Single page only; nothing is retained            |
 
 Choose broadcasting when you need:
 
-- **Multiple independent channels** between apps (e.g., selection events separate from configuration changes)
-- **Sticky state** that late-mounting apps can read immediately
-- **Source identity** — knowing which app sent a message
-- **Structured coordination** declared in the manifest for discoverability
+- **Multiple independent channels** between apps (for example, selection events separate from configuration changes)
+- **Source identity** — knowing which app instance sent each message
+- **A declared contract** — channels named in the manifest so the app's inputs and outputs are explicit
 
-## Architecture
+## How it works
 
-```
-┌─────────────────────────────────────────────────────┐
-│                    Domo Page (host)                  │
-│                                                     │
-│   ┌───────────┐     PageBus      ┌───────────┐     │
-│   │  App A    │◄────────────────►│  App B    │     │
-│   │ (iframe)  │    (broker)      │ (iframe)  │     │
-│   └───────────┘        ▲        └───────────┘     │
-│                        │                           │
-│                  ┌─────┴─────┐                     │
-│                  │  App C    │                     │
-│                  │ (iframe)  │                     │
-│                  └───────────┘                     │
-└─────────────────────────────────────────────────────┘
+Every message travels **iframe → host → iframe**. The publishing app posts a message to the Domo page; the host validates and routes it; each subscribing app receives it. There is no direct iframe-to-iframe path.
+
+```mermaid
+flowchart LR
+    A["App A<br/>(iframe)"] -- publish --> H
+    B["App B<br/>(iframe)"] -- publish --> H
+    C["App C<br/>(iframe)"] -- publish --> H
+    H -- deliver --> A
+    H -- deliver --> B
+    H -- deliver --> C
+    subgraph page["Domo page — one bus per page"]
+        H{{"Host bus<br/>validate · stamp · rate-limit · route"}}
+    end
 ```
 
-Key architectural properties:
+Key properties:
 
-- **Host-mediated** — All messages route through the Domo page (DomoWeb). Apps never see each other's iframes or postMessage traffic directly.
-- **Per-page lifecycle** — The bus is created when the first app mounts and cleared entirely on page navigation. Subscriptions and sticky values do not persist across pages.
-- **Broker-only** — The host validates, stamps, rate-limits, and routes. It does not transform payloads.
+- **Host-mediated** — Every message routes through the Domo page. Apps never see each other's iframes or `postMessage` traffic.
+- **One bus per page** — A single bus is shared by all app cards on the page and is destroyed when you navigate away. There is no persistence and no cross-page messaging.
+- **Broker only** — The host validates the channel, stamps the sender and a timestamp, enforces limits, and routes. It does not transform your payload.
+- **Fire-and-forget** — The bus holds no history. It delivers each message to the apps subscribed **at that moment** and keeps nothing. An app that subscribes later sees only messages published after it joins.
+- **No echo** — A publisher never receives its own message, even if it subscribes to the same channel.
+
+### Message flow
+
+```mermaid
+sequenceDiagram
+    participant A as App A (publisher)
+    participant H as Domo page (host)
+    participant B as App B (subscriber)
+    A->>H: domo.broadcast('selection:changed', payload)
+    Note over H: check channel, payload size, rate limit
+    Note over H: stamp sourceAppId + timestamp
+    H->>B: deliver { channel, payload, sourceAppId, timestamp }
+    B->>B: onBroadcast('selection:changed') callback fires
+    Note over A,H: publisher is skipped — no echo
+```
 
 ## Core concepts
 
@@ -62,66 +77,40 @@ domo.broadcast('selection:changed', { rowId: 42 });
 domo.onBroadcast('selection:changed', (msg) => { /* ... */ });
 ```
 
-Channel naming conventions:
+Conventions:
 
-- Use `namespace:event` format (e.g., `filter:region`, `chart:hover`, `config:theme`)
-- Channels are exact strings — no wildcards
-- Channels starting with `domo:` are **reserved** for system events and cannot be used by apps
+- Use a `namespace:event` name (for example, `filter:region`, `chart:hover`, `config:theme`).
+- Channel names are exact strings, compared literally.
+- Names beginning with `domo:` are **reserved** for the host and are rejected.
 
 ### Messages
 
-Every delivered message has this shape:
+Each delivered message has this shape:
 
 ```typescript
 interface BroadcastMessage {
-  channel: string;     // The channel this message was published to
-  payload: unknown;    // The data sent by the publisher
-  sourceAppId: string; // Host-stamped ID of the publishing app instance
-  timestamp: number;   // Host-assigned timestamp (ms since epoch)
+  channel: string;     // Channel the message was published to
+  payload: unknown;    // Data sent by the publisher
+  sourceAppId: string; // ID of the app instance that published it
+  timestamp: number;   // When the host delivered the message (ms since epoch)
 }
 ```
 
-The `sourceAppId` is stamped by the host and cannot be spoofed. Use it to identify which app sent a message or to filter messages from a specific source.
+- **`sourceAppId`** identifies the *card instance* that published the message. The host assigns it — an app cannot set or fake it — so subscribers can trust it. Two copies of the same app on one page have different `sourceAppId` values.
+- **`timestamp`** is assigned by the host when it routes the message.
 
-### Sticky messages
+### Declaring channels
 
-A **sticky** message is retained by the bus. When a new subscriber joins a sticky channel, it immediately receives the last published value — even if that value was published before the subscriber existed.
-
-```javascript
-// Publisher: send sticky state
-domo.broadcast('config:theme', { mode: 'dark', accent: '#4A90D9' }, { sticky: true });
-
-// Subscriber (mounts later): receives the last value immediately
-domo.onBroadcast('config:theme', (msg) => {
-  applyTheme(msg.payload);
-});
-```
-
-Use sticky messages for **state** that late-mounting apps need (theme, selected record, configuration). Use non-sticky messages for **events** that are only relevant at the moment they fire (hover, click, transient notifications).
-
-### Manifest declarations
-
-Apps declare their broadcast channels in `manifest.json`. Declarations serve three purposes:
-
-1. **Discoverability** — The App Store and wiring UIs show what an app publishes and subscribes to
-2. **Pro Code Editor** — Broadcasting on an undeclared channel logs a `console.warn()`
-3. **Domo page** — Broadcasting on an undeclared channel throws an error
+Apps declare the channels they use in `manifest.json`. Declarations do real work: **in production, an app receives a channel only if that channel is listed under `subscribes`.** The host subscribes each app to its declared channels when the app loads.
 
 ```json
 {
   "channels": {
     "publishes": [
-      {
-        "name": "selection:changed",
-        "description": "Fires when the user selects a data point",
-        "sticky": false
-      }
+      { "name": "selection:changed", "description": "Fires when the user selects a row" }
     ],
     "subscribes": [
-      {
-        "name": "filter:region",
-        "description": "Applies a region filter to the visualization"
-      }
+      { "name": "filter:region", "description": "Applies a region filter" }
     ]
   }
 }
@@ -129,74 +118,85 @@ Apps declare their broadcast channels in `manifest.json`. Declarations serve thr
 
 See [The Manifest File](/portal/Apps/App-Framework/Guides/manifest#channels) for the full schema.
 
-## Security model
+## Limits and safety
 
-App Broadcasting enforces several security primitives at the host level:
+The host enforces these on every message, in every environment:
 
-### Reserved namespace
+| Rule               | Detail                                                                                                                 |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Reserved namespace | Channels starting with `domo:` are rejected (case-insensitive), on both publish and subscribe.                         |
+| Source identity    | The host stamps each message with the sender's `sourceAppId`; it cannot be spoofed.                                    |
+| Rate limit         | 100 messages per second, per app. The bus drops messages beyond the limit.                                             |
+| Payload size       | 64 KB per message when serialized. Larger or non-serializable payloads are rejected.                                   |
+| Page isolation     | The bus lives only for the current page. Navigating away clears every subscription; nothing persists or crosses pages. |
 
-Channel names starting with `domo:` are reserved for host-emitted system events. The SDK rejects these client-side before any message is sent, and the host rejects them server-side as a defense-in-depth measure.
+## Error handling
 
-### Source identity
+`domo.broadcast()` returns immediately and **never throws**. If the host rejects a publish, it notifies **only the sending app**, and the SDK writes a warning to the browser console — it does not raise an exception or reject a promise.
 
-The host stamps every message with the publishing app's `sourceAppId`. This value is derived from the iframe's registration — apps cannot set or override it. Subscribers can trust `msg.sourceAppId` to identify the true sender.
+```
+[domo.broadcast] PAYLOAD_TOO_LARGE — Payload size 91234 bytes exceeds limit of 65536 bytes (channel: data:export)
+```
 
-### Rate limiting
+| Code                       | Meaning                                                         |
+| -------------------------- | --------------------------------------------------------------- |
+| `RESERVED_NAMESPACE`       | Channel starts with `domo:`                                     |
+| `PAYLOAD_TOO_LARGE`        | Serialized payload exceeds 64 KB                                |
+| `PAYLOAD_NOT_SERIALIZABLE` | Payload can't be serialized (for example, a circular reference) |
+| `RATE_LIMIT_EXCEEDED`      | More than 100 messages in one second                            |
+| `FEATURE_DISABLED`         | The `app-broadcasting` feature switch is off                    |
 
-Each app is limited to **100 messages per second** (configurable by instance admins). Messages exceeding this limit are rejected, and the SDK surfaces an error.
+## Syncing current state on mount
 
-### Payload size
+Because the bus keeps no history, an app that mounts after a value was published won't have it. To catch up, have the new subscriber **ask for the current state** and let the owner republish it:
 
-Each message payload is capped at **64 KB** when serialized. Oversized payloads are rejected client-side by the SDK before reaching the bus.
+```javascript
+// Newcomer: subscribe, then request the current value
+domo.onBroadcast('selection:changed', (msg) => render(msg.payload));
+domo.broadcast('selection:request', {});
 
-### Duplicate filtering
+// State owner: answer requests by republishing the latest value
+let current = null;
+domo.onBroadcast('selection:request', () => {
+  if (current) domo.broadcast('selection:changed', current);
+});
+```
 
-The bus tracks the last published payload for each channel and drops messages whose serialized payload is an exact match of the previous value. This prevents redundant subscriber calls when the same state is published repeatedly (for example, clicking the same row twice).
-
-If you need to force a re-delivery of the same value — for example, to re-trigger a side effect — include a sequence number or timestamp in the payload.
-
-### Page-scoped isolation
-
-The bus exists only within a single page load. There is no cross-page communication, no persistence, and no way for apps on different pages to exchange messages. Navigating away clears all subscriptions and sticky state.
-
-## Comparison with variables and filters
-
-| Feature | Broadcasting | Variables | Filters |
-| --- | --- | --- | --- |
-| Data shape | Any serializable value (up to 64 KB) | Primitive values | Filter objects |
-| Persistence | Page load only | Saved with page | Saved with page |
-| Late-subscriber replay | Yes (sticky channels) | Yes (always current) | Yes (current state) |
-| Multiple channels | Yes (unlimited channels) | Yes (named variables) | Single filter set |
-| Source identity | Yes (`sourceAppId`) | No | No |
-| Event semantics | Pub/sub (fire and forget) | State (always last value) | State |
-| Cross-page | No | Yes | Yes |
-
-**Rule of thumb:** Use variables or filters when you need state that persists across navigation. Use broadcasting when you need real-time, channel-based coordination within a single page session.
+This keeps late-mounting apps in sync without relying on any retained state.
 
 ## Lifecycle
 
-1. **Page loads** — The bus is created (empty, no subscriptions)
-2. **Apps mount** — Each app subscribes to its declared channels via `domo.onBroadcast()`
-3. **Messages flow** — Apps publish and receive messages in real time
-4. **Sticky replay** — Late-mounting apps receive the last sticky value for each channel they subscribe to
-5. **Page navigates** — The bus is destroyed; all subscriptions and sticky state are cleared
+<Steps>
+  <Step title="Page loads">
+    The bus is created for the page (empty — no subscriptions yet).
+  </Step>
+  <Step title="Apps mount">
+    The host subscribes each app to the channels it declared under `subscribes`.
+  </Step>
+  <Step title="Messages flow">
+    Apps publish and receive messages in real time through the host.
+  </Step>
+  <Step title="Page navigates">
+    The bus is destroyed. All subscriptions are cleared; nothing is retained.
+  </Step>
+</Steps>
 
 ## Quick start
 
-**Publisher app** (`manifest.json`):
+**Publisher** — `manifest.json`:
 
 ```json
 {
   "name": "Data Selector",
   "channels": {
     "publishes": [
-      { "name": "selection:changed", "description": "User selected a row", "sticky": true }
+      { "name": "selection:changed", "description": "User selected a row" }
     ]
   }
 }
 ```
 
-**Publisher app** (`app.js`):
+**Publisher** — `app.js`:
 
 ```javascript
 import domo from 'ryuu.js';
@@ -205,25 +205,25 @@ function onRowClick(row) {
   domo.broadcast('selection:changed', {
     id: row.id,
     name: row.name,
-    region: row.region
-  }, { sticky: true });
+    region: row.region,
+  });
 }
 ```
 
-**Subscriber app** (`manifest.json`):
+**Subscriber** — `manifest.json`:
 
 ```json
 {
   "name": "Detail Viewer",
   "channels": {
     "subscribes": [
-      { "name": "selection:changed", "description": "Show detail for selected row" }
+      { "name": "selection:changed", "description": "Show detail for the selected row" }
     ]
   }
 }
 ```
 
-**Subscriber app** (`app.js`):
+**Subscriber** — `app.js`:
 
 ```javascript
 import domo from 'ryuu.js';
@@ -234,8 +234,22 @@ domo.onBroadcast('selection:changed', (msg) => {
 });
 ```
 
+## Broadcasting vs. variables and filters
+
+| Feature                | Broadcasting                         | Variables             | Filters             |
+| ---------------------- | ------------------------------------ | --------------------- | ------------------- |
+| Data shape             | Any serializable value (up to 64 KB) | Primitive values      | Filter objects      |
+| Persistence            | Current page only                    | Saved with the page   | Saved with the page |
+| Late-subscriber replay | No (fire-and-forget)                 | Yes (always current)  | Yes (current state) |
+| Multiple channels      | Yes (unlimited)                      | Yes (named variables) | Single filter set   |
+| Source identity        | Yes (`sourceAppId`)                  | No                    | No                  |
+| Semantics              | Pub/sub events                       | Shared state          | Shared state        |
+| Cross-page             | No                                   | Yes                   | Yes                 |
+
+**Rule of thumb:** Use variables or filters for state that should survive navigation. Use broadcasting for real-time, channel-based coordination within a single page.
+
 ## Next steps
 
-- [Broadcast SDK Reference](/portal/Apps/App-Framework/Tools/domo-js#broadcasting) — Full API documentation for `domo.broadcast()`, `domo.onBroadcast()`, and helper methods
+- [Broadcast SDK Reference](/portal/Apps/App-Framework/Tools/domo-js#broadcasting) — `domo.broadcast()`, `domo.onBroadcast()`, and the source-filtering helpers
 - [The Manifest File](/portal/Apps/App-Framework/Guides/manifest#channels) — Channel declaration schema
-- [Cross-App Broadcasting Tutorial](/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting) — Step-by-step tutorial building a filter-and-chart coordination pattern
+- [Cross-App Broadcasting Tutorial](/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting) — Build two apps that coordinate a selection and a detail view

--- a/portal/Apps/App-Framework/Guides/manifest.mdx
+++ b/portal/Apps/App-Framework/Guides/manifest.mdx
@@ -18,7 +18,7 @@ The manifest file is the configuration file used to provide meta-data about an A
 | `ignore`          | List            | Instructs the CLI to ignore certain files when publishing. | Accepts an array of glob patterns.                                                                                                                                                                                                                             | Optional |
 | `id`              | String          | This is a unique identifier for your App Design.           | It is added to the manifest automatically by the command line tool the first time you publish your design via `domo publish`.                                                                                                                                  | Required |
 | `proxyId`         | String          | This is an id of a card you want to impersonate.           | It is required if you want to be able to develop locally against Domo Workflows, Code Engine, or AppDB.                                                                                                                                                        | Optional | [Getting a proxyId](#getting-a-proxyid-advanced)                                                     |
-| `channels`        | Object          | Declares broadcast topics the app publishes and subscribes to. | Enables cross-app communication via App Broadcasting. Object with `publishes` and `subscribes` arrays.                                                                                                                                                        | Optional | [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting)                                   |
+| `channels`        | Object          | Declares broadcast channels the app publishes and subscribes to. | Enables cross-app communication via App Broadcasting. Object with `publishes` and `subscribes` arrays.                                                                                                                                                        | Optional | [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting)                                   |
 
 ### Example Manifest
 
@@ -523,7 +523,7 @@ This is the actual name of the column in the DataSet that the field alias gets m
 
 ---
 
-The `channels` property declares the broadcast topics your app uses for cross-app communication via [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting). Declaring channels enables the wiring UI in App Studio, makes your app discoverable in the App Store, and allows DevTools to validate message traffic.
+The `channels` property declares the broadcast channels your app uses for cross-app communication via [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting). Declaring channels enables the wiring UI in App Studio, makes your app discoverable in the App Store, and allows DevTools to validate message traffic.
 
 ```json
 "channels": {
@@ -546,26 +546,26 @@ The `channels` property declares the broadcast topics your app uses for cross-ap
 
 #### publishes
 
-An array of topics this app sends messages to. Each entry has:
+An array of channels this app sends messages to. Each entry has:
 
 | Property | Type | Description | Required |
 | --- | --- | --- | --- |
-| `name` | String | Topic name (exact string, no wildcards). Cannot start with `domo:`. | Required |
-| `description` | String | Human-readable description of what this topic carries | Required |
+| `name` | String | Channel name (exact string, no wildcards). Cannot start with `domo:`. | Required |
+| `description` | String | Human-readable description of what this channel carries | Required |
 | `sticky` | Boolean | If `true`, the last published value is retained and replayed to late subscribers. Defaults to `false`. | Optional |
 | `schema` | Object | JSON Schema describing the payload shape. Advisory in v1 — DevTools warns on mismatches but the runtime stays permissive. | Optional |
 
 #### subscribes
 
-An array of topics this app listens to. Each entry has:
+An array of channels this app listens to. Each entry has:
 
 | Property | Type | Description | Required |
 | --- | --- | --- | --- |
-| `name` | String | Topic name to subscribe to. Cannot start with `domo:`. | Required |
-| `description` | String | Human-readable description of how this app uses the topic | Required |
+| `name` | String | Channel name to subscribe to. Cannot start with `domo:`. | Required |
+| `description` | String | Human-readable description of how this app uses the channel | Required |
 
 <Note>
-**Note:** Channel declarations are required capability declarations. In production, the host rejects messages on undeclared topics. During local development (WIDE mode), undeclared topics produce a console warning but are not blocked.
+**Note:** Channel declarations are required capability declarations. In production, the host rejects messages on undeclared channels. During local development (WIDE mode), undeclared channels produce a console warning but are not blocked.
 </Note>
 
 ### Getting a proxyId (Advanced)

--- a/portal/Apps/App-Framework/Guides/manifest.mdx
+++ b/portal/Apps/App-Framework/Guides/manifest.mdx
@@ -5,20 +5,20 @@ permalink: af407395c766b-the-manifest-file
 
 The manifest file is the configuration file used to provide meta-data about an App Design and the resources that it needs access to in Domo. The manifest file should be placed in the base directory of the App Design and should be named <strong>manifest.json</strong>.
 
-| Property          | Type            | Description                                                | Notes                                                                                                                                                                                                                                                          | Required | Guide                                                                                                |
-| ----------------- | --------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `name`            | String          | The name of App Design                                     | An App Design can have many App Instances (Cards in Domo) - each App Instance has its own name.                                                                                                                                                                | Required |
-| `version`         | String          | The version of your App Design.                            |                                                                                                                                                                                                                                                                | Required |
-| `size`            | Object          | The size of your App.                                      | Object with `width` and `height` properties defined on a scale of 1-6                                                                                                                                                                                          | Required |
-| `fullpage`        | Boolean         | Allows the app to be viewed in full page mode.             |                                                                                                                                                                                                                                                                | Optional |
-| `datasetsMapping` | List of Objects | A list of Datasets that the App Design uses.               | Each object corresponds to one Dataset and should include an `alias`, `dataSetId`, and `fields` property. If the App Design doesn't use Datasets, `datasetsMapping` can be an empty list `[]`                                                                  | Required |
-| `collections`     | List of Objects | A list of AppDB collections that the App Design uses       | Each object corresponds to one AppDB collection and should include a `name`, `schema` (optional), and `syncEnabled` property. If your App Design leverages AppDB collections, you'll also need to setup a `proxyId` property in the manifest file.             | Optional | [AppDB API](/portal/API-Reference/app-framework-apis/AppDB-API)                                      |
-| `workflowMapping` | List of Objects | A list of Workflows that the App Design uses.              | Each object corresponds to one Workflow and should include an `alias` and `parameters` property. If your App Design leverages Workflows, you'll also need to setup a `proxyId` property in the manifest file.                                                  | Optional | [Hitting a Workflow from an App](/portal/Apps/App-Framework/Guides/hitting-a-workflow)               |
-| `packageMapping`  | List of Objects | A list of Code Engine packages that the App Design uses.   | Each object corresponds to one Code Engine package and should include an `alias`, `parameters` (if applicable), and `output` property. If your App Design leverages Code Engine packages, you'll also need to setup a `proxyId` property in the manifest file. | Optional | [Hitting Code Engine from an App](/portal/Apps/App-Framework/Guides/hitting-code-engine-from-an-app) |
-| `ignore`          | List            | Instructs the CLI to ignore certain files when publishing. | Accepts an array of glob patterns.                                                                                                                                                                                                                             | Optional |
-| `id`              | String          | This is a unique identifier for your App Design.           | It is added to the manifest automatically by the command line tool the first time you publish your design via `domo publish`.                                                                                                                                  | Required |
-| `proxyId`         | String          | This is an id of a card you want to impersonate.           | It is required if you want to be able to develop locally against Domo Workflows, Code Engine, or AppDB.                                                                                                                                                        | Optional | [Getting a proxyId](#getting-a-proxyid-advanced)                                                     |
-| `channels`        | Object          | Declares broadcast channels the app publishes and subscribes to. | Enables cross-app communication via App Broadcasting. Object with `publishes` and `subscribes` arrays.                                                                                                                                                        | Optional | [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting)                                   |
+| Property          | Type            | Description                                                      | Notes                                                                                                                                                                                                                                                          | Required | Guide                                                                                                |
+| ----------------- | --------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `name`            | String          | The name of App Design                                           | An App Design can have many App Instances (Cards in Domo) - each App Instance has its own name.                                                                                                                                                                | Required |                                                                                                      |
+| `version`         | String          | The version of your App Design.                                  |                                                                                                                                                                                                                                                                | Required |                                                                                                      |
+| `size`            | Object          | The size of your App.                                            | Object with `width` and `height` properties defined on a scale of 1-6                                                                                                                                                                                          | Required |                                                                                                      |
+| `fullpage`        | Boolean         | Allows the app to be viewed in full page mode.                   |                                                                                                                                                                                                                                                                | Optional |                                                                                                      |
+| `datasetsMapping` | List of Objects | A list of Datasets that the App Design uses.                     | Each object corresponds to one Dataset and should include an `alias`, `dataSetId`, and `fields` property. If the App Design doesn't use Datasets, `datasetsMapping` can be an empty list `[]`                                                                  | Required |                                                                                                      |
+| `collections`     | List of Objects | A list of AppDB collections that the App Design uses             | Each object corresponds to one AppDB collection and should include a `name`, `schema` (optional), and `syncEnabled` property. If your App Design leverages AppDB collections, you'll also need to setup a `proxyId` property in the manifest file.             | Optional | [AppDB API](/portal/API-Reference/app-framework-apis/AppDB-API)                                      |
+| `workflowMapping` | List of Objects | A list of Workflows that the App Design uses.                    | Each object corresponds to one Workflow and should include an `alias` and `parameters` property. If your App Design leverages Workflows, you'll also need to setup a `proxyId` property in the manifest file.                                                  | Optional | [Hitting a Workflow from an App](/portal/Apps/App-Framework/Guides/hitting-a-workflow)               |
+| `packageMapping`  | List of Objects | A list of Code Engine packages that the App Design uses.         | Each object corresponds to one Code Engine package and should include an `alias`, `parameters` (if applicable), and `output` property. If your App Design leverages Code Engine packages, you'll also need to setup a `proxyId` property in the manifest file. | Optional | [Hitting Code Engine from an App](/portal/Apps/App-Framework/Guides/hitting-code-engine-from-an-app) |
+| `ignore`          | List            | Instructs the CLI to ignore certain files when publishing.       | Accepts an array of glob patterns.                                                                                                                                                                                                                             | Optional |                                                                                                      |
+| `id`              | String          | This is a unique identifier for your App Design.                 | It is added to the manifest automatically by the command line tool the first time you publish your design via `domo publish`.                                                                                                                                  | Required |                                                                                                      |
+| `proxyId`         | String          | This is an id of a card you want to impersonate.                 | It is required if you want to be able to develop locally against Domo Workflows, Code Engine, or AppDB.                                                                                                                                                        | Optional | [Getting a proxyId](#getting-a-proxyid-advanced)                                                     |
+| `channels`        | Object          | Declares broadcast channels the app publishes and subscribes to. | Enables cross-app communication via App Broadcasting. Object with `publishes` and `subscribes` arrays.                                                                                                                                                         | Optional | [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting)                                   |
 
 ### Example Manifest
 
@@ -111,8 +111,7 @@ Here is an example demonstrating a complete manifest file.
     "publishes": [
       {
         "name": "selection:changed",
-        "description": "Fires when the user selects a row",
-        "sticky": true
+        "description": "Fires when the user selects a row"
       }
     ],
     "subscribes": [
@@ -523,16 +522,14 @@ This is the actual name of the column in the DataSet that the field alias gets m
 
 ---
 
-The `channels` property declares the broadcast channels your app uses for cross-app communication via [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting). Declaring channels enables the wiring UI in App Studio, makes your app discoverable in the App Store, and allows DevTools to validate message traffic.
+The `channels` property declares the broadcast channels your app uses for cross-app communication via [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting). Declarations document your app's inputs and outputs — and they do real work: in production, an app receives a channel only if that channel is listed under `subscribes`.
 
 ```json
 "channels": {
   "publishes": [
     {
       "name": "selection:changed",
-      "description": "Fires when the user selects a data point",
-      "sticky": true,
-      "schema": {}
+      "description": "Fires when the user selects a data point"
     }
   ],
   "subscribes": [
@@ -548,24 +545,22 @@ The `channels` property declares the broadcast channels your app uses for cross-
 
 An array of channels this app sends messages to. Each entry has:
 
-| Property | Type | Description | Required |
-| --- | --- | --- | --- |
-| `name` | String | Channel name (exact string, no wildcards). Cannot start with `domo:`. | Required |
-| `description` | String | Human-readable description of what this channel carries | Required |
-| `sticky` | Boolean | If `true`, the last published value is retained and replayed to late subscribers. Defaults to `false`. | Optional |
-| `schema` | Object | JSON Schema describing the payload shape. Advisory in v1 — DevTools warns on mismatches but the runtime stays permissive. | Optional |
+| Property      | Type   | Description                                                                   | Required |
+| ------------- | ------ | ----------------------------------------------------------------------------- | -------- |
+| `name`        | String | Channel name (exact string). Cannot start with `domo:`. Max 256 characters.   | Required |
+| `description` | String | Human-readable description of what this channel carries. Max 2048 characters. | Optional |
 
 #### subscribes
 
 An array of channels this app listens to. Each entry has:
 
-| Property | Type | Description | Required |
-| --- | --- | --- | --- |
-| `name` | String | Channel name to subscribe to. Cannot start with `domo:`. | Required |
-| `description` | String | Human-readable description of how this app uses the channel | Required |
+| Property      | Type   | Description                                                                       | Required |
+| ------------- | ------ | --------------------------------------------------------------------------------- | -------- |
+| `name`        | String | Channel name to subscribe to. Cannot start with `domo:`. Max 256 characters.      | Required |
+| `description` | String | Human-readable description of how this app uses the channel. Max 2048 characters. | Optional |
 
 <Note>
-**Note:** Channel declarations are required capability declarations. In production, the host rejects messages on undeclared channels. During local development (WIDE mode), undeclared channels produce a console warning but are not blocked.
+**Note:** In production, an app receives a channel only if it is declared under `subscribes` — the host subscribes each app to its declared channels when it loads. Publishing is not restricted to declared channels, but declaring what you publish keeps your app's contract explicit. In the App Studio and Pro Code editors, publishing or subscribing to an undeclared channel logs a console warning. You can declare up to 100 channels per direction, names must be unique across `publishes` and `subscribes`, and the bus is fire-and-forget — it does not retain or replay values.
 </Note>
 
 ### Getting a proxyId (Advanced)

--- a/portal/Apps/App-Framework/Guides/overview.mdx
+++ b/portal/Apps/App-Framework/Guides/overview.mdx
@@ -89,13 +89,13 @@ Implement real-time or scheduled data updates in your apps to keep information f
 
 ### [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting)
 
-Enable real-time communication between Custom Apps on the same page using a topic-based pub/sub message bus.
+Enable real-time communication between Custom Apps on the same page using a channel-based pub/sub message bus.
 
 **Covers:**
 
-- Publishing and subscribing to named topics
-- Sticky messages for late-mounting apps
-- Security model (source identity, rate limits, reserved namespaces)
+- Publishing and subscribing to named channels
+- Syncing current state when an app mounts late
+- Limits and safety (source identity, rate limits, reserved namespaces)
 - Manifest channel declarations
 - Architecture and lifecycle
 

--- a/portal/Apps/App-Framework/Tools/domo-js.mdx
+++ b/portal/Apps/App-Framework/Tools/domo-js.mdx
@@ -16,15 +16,15 @@ domo.js (published as `ryuu.js`) is the official JavaScript SDK for building Cus
 
 ## What's New in v6
 
-| Feature | Description |
-| --- | --- |
-| `domo.broadcast()` | Channel-based cross-app communication with sticky replay and source identity |
-| `domo.intercept()` | Register request middleware — logging, retries, custom headers |
-| Structured errors | `DomoHttpError`, `DomoAuthError`, `DomoConnectionError`, `DomoValidationError`, `DomoTimeoutError` |
-| `RequestOptions.schema` | Runtime response validation with a custom parse function |
-| `domo.debug` | Category-based debug logging, persisted via `localStorage` |
-| Service namespaces | `domo.data`, `domo.appdb`, `domo.ai`, `domo.workflow`, `domo.codeEngine` |
-| Optimized bundle | Reduced bundle size, zero runtime dependencies |
+| Feature                 | Description                                                                                        |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
+| `domo.broadcast()`      | Channel-based cross-app communication with source identity                                         |
+| `domo.intercept()`      | Register request middleware — logging, retries, custom headers                                     |
+| Structured errors       | `DomoHttpError`, `DomoAuthError`, `DomoConnectionError`, `DomoValidationError`, `DomoTimeoutError` |
+| `RequestOptions.schema` | Runtime response validation with a custom parse function                                           |
+| `domo.debug`            | Category-based debug logging, persisted via `localStorage`                                         |
+| Service namespaces      | `domo.data`, `domo.appdb`, `domo.ai`, `domo.workflow`, `domo.codeEngine`                           |
+| Optimized bundle        | Reduced bundle size, zero runtime dependencies                                                     |
 
 For a full list of breaking changes, see [Migration from v5](#migration-from-v5).
 
@@ -58,7 +58,7 @@ domo.onFiltersUpdated((filters) => {
 - **AI Services** — Text generation and text-to-SQL via Domo's AI Service Layer
 - **HTTP API Access** — Authenticated requests to Domo datasets, datastores, and APIs
 - **Real-time Events** — Listen for dataset updates, filter changes, and variable updates
-- **App Broadcasting** — Channel-based pub/sub between apps on the same page with sticky replay and source identity
+- **App Broadcasting** — Channel-based pub/sub between apps on the same page with source identity
 - **Filter Management** — Get and set page-level filters programmatically
 - **Variable Management** — Access and update page variables
 - **Custom App Data** — Send custom data between apps on the same page
@@ -210,13 +210,13 @@ import {
 } from 'ryuu.js';
 ```
 
-| Class | Thrown When | Key Properties |
-| --- | --- | --- |
-| `DomoHttpError` | Non-2xx HTTP response | `status`, `statusText`, `body`, `headers` |
-| `DomoAuthError` | 401 or 403 response | Extends `DomoHttpError` |
-| `DomoConnectionError` | Network failure (fetch rejects) | — |
-| `DomoValidationError` | Invalid input or schema parse failure | `errors[]` |
-| `DomoTimeoutError` | Request or message timeout | `url` |
+| Class                 | Thrown When                           | Key Properties                            |
+| --------------------- | ------------------------------------- | ----------------------------------------- |
+| `DomoHttpError`       | Non-2xx HTTP response                 | `status`, `statusText`, `body`, `headers` |
+| `DomoAuthError`       | 401 or 403 response                   | Extends `DomoHttpError`                   |
+| `DomoConnectionError` | Network failure (fetch rejects)       | —                                         |
+| `DomoValidationError` | Invalid input or schema parse failure | `errors[]`                                |
+| `DomoTimeoutError`    | Request or message timeout            | `url`                                     |
 
 <Note>
 Always check `DomoAuthError` before `DomoHttpError` in your catch block — `DomoAuthError` extends `DomoHttpError`, so an `instanceof DomoHttpError` check will also match auth errors.
@@ -706,7 +706,7 @@ domo.onAppDataUpdated((data) => {
 **Use Case:** Enable communication between multiple Custom Apps on the same Domo page.
 
 <Note>
-**Note:** For new apps, prefer [App Broadcasting](#broadcasting) over `onAppDataUpdated`. Broadcasting provides channel-based routing, sticky replay, source identity, and manifest-declared channels.
+**Note:** For new apps, prefer [App Broadcasting](#broadcasting) over `onAppDataUpdated`. Broadcasting provides channel-based routing, source identity, and manifest-declared channels.
 </Note>
 
 ---
@@ -716,7 +716,7 @@ domo.onAppDataUpdated((data) => {
 The broadcasting methods provide a channel-based pub/sub system for cross-app communication. Apps publish named messages and subscribe to channels — the host routes messages between apps on the same page.
 
 <Note>
-**Note:** App Broadcasting requires the `app-broadcasting` feature switch. When disabled, all methods are safe no-ops with a one-time `console.warn`.
+**Note:** App Broadcasting requires the `app-broadcasting` feature switch. While it is disabled, publishing is safe but has no effect — the host rejects each message with a `FEATURE_DISABLED` notice that the SDK logs to the console, and no messages are delivered.
 </Note>
 
 See the [App Broadcasting Guide](/portal/Apps/App-Framework/Guides/broadcasting) for conceptual overview, architecture, and security model.
@@ -725,7 +725,7 @@ See the [App Broadcasting Guide](/portal/Apps/App-Framework/Guides/broadcasting)
 
 #### `domo.onBroadcast(channel, handler)`
 
-Subscribe to messages on a channel. If the channel is sticky and a value has already been published, the handler fires immediately with the last value.
+Subscribe to messages on a channel. The handler fires each time a message is published to the channel *after* you subscribe. The bus keeps no history, so a new subscriber does not receive earlier messages.
 
 **Parameters:**
 
@@ -740,8 +740,8 @@ Subscribe to messages on a channel. If the channel is sticky and a value has alr
 interface BroadcastMessage {
   channel: string;     // Channel the message was published to
   payload: unknown;    // Data sent by the publisher
-  sourceAppId: string; // Host-stamped app instance ID (trustworthy)
-  timestamp: number;   // Host-assigned timestamp (ms since epoch)
+  sourceAppId: string; // Publishing card instance ID, host-stamped (trustworthy)
+  timestamp: number;   // Host-assigned delivery time (ms since epoch)
 }
 ```
 
@@ -861,12 +861,12 @@ domo.requestAppDataUpdate({
 ```
 
 <Note>
-**Note:** For new apps, prefer [`domo.broadcast()`](#domo-broadcast-channel-payload-opts) over `requestAppDataUpdate`. Broadcasting provides channel routing, sticky state, and source identity.
+**Note:** For new apps, prefer [`domo.broadcast()`](#domo-broadcast-channel-payload) over `requestAppDataUpdate`. Broadcasting provides channel routing and source identity.
 </Note>
 
 ---
 
-#### `domo.broadcast(channel, payload, opts?)`
+#### `domo.broadcast(channel, payload)`
 
 Publish a message to all apps subscribed to the given channel on the same page.
 
@@ -874,23 +874,16 @@ Publish a message to all apps subscribed to the given channel on the same page.
 
 - `channel` (string, required) — Channel name. Cannot start with `domo:`.
 - `payload` (unknown, required) — Any serializable data. Must be under 64 KB when serialized.
-- `opts` (object, optional):
-  - `sticky` (boolean) — If `true`, the bus retains this value and replays it to future subscribers. Defaults to `false`.
 
-**Returns:** `void`
+**Returns:** `void` — Returns immediately and never throws.
 
-**Throws:**
-
-- `Error('Reserved namespace')` — Channel starts with `domo:`
-- `Error('Payload too large')` — Serialized payload exceeds 64 KB
-- `Error('Undeclared channel')` — Channel is not declared in `manifest.json` (Domo page only; Pro Code Editor logs a `console.warn()` instead)
+If the host rejects a message, it notifies only the sending app and the SDK logs a `console.warn` in the form `[domo.broadcast] <CODE> — <message>`. It does not throw or reject a promise. Rejection codes: `RESERVED_NAMESPACE`, `PAYLOAD_TOO_LARGE`, `PAYLOAD_NOT_SERIALIZABLE`, `RATE_LIMIT_EXCEEDED`, `FEATURE_DISABLED`.
 
 ```javascript
 // Fire-and-forget event
 domo.broadcast('chart:hover', { seriesId: 'revenue', index: 3 });
 
-// Sticky state (retained for late subscribers)
-domo.broadcast('selection:changed', { id: 42, name: 'Acme Corp' }, { sticky: true });
+domo.broadcast('selection:changed', { id: 42, name: 'Acme Corp' });
 ```
 
 ---
@@ -1252,10 +1245,10 @@ const rows = (await domo.data.query('sales')) as SalesRecord[];
 
 domo.js detects the platform and routes messages through the appropriate bridge automatically. No configuration needed.
 
-| Platform | Bridge used |
-| --- | --- |
-| Desktop / Web | MessageChannel + `window.parent.postMessage` |
-| iOS | `webkit.messageHandlers` (`domofilter`, `domovariable`) |
+| Platform          | Bridge used                                                 |
+| ----------------- | ----------------------------------------------------------- |
+| Desktop / Web     | MessageChannel + `window.parent.postMessage`                |
+| iOS               | `webkit.messageHandlers` (`domofilter`, `domovariable`)     |
 | Android / Flutter | Global objects (`window.domofilter`, `window.domovariable`) |
 
 **Platform detection:**
@@ -1304,13 +1297,13 @@ localStorage.__domo_debug__ = '["all"]';
 
 **Debug categories:**
 
-| Category | What it logs |
-| --- | --- |
-| `http` | Every request: method, URL, headers, response status and body |
-| `messages` | All MessageChannel and postMessage traffic (inbound and outbound) |
-| `filters` | Filter update events and subscriptions |
-| `variables` | Variable update events and subscriptions |
-| `all` | Everything above |
+| Category    | What it logs                                                      |
+| ----------- | ----------------------------------------------------------------- |
+| `http`      | Every request: method, URL, headers, response status and body     |
+| `messages`  | All MessageChannel and postMessage traffic (inbound and outbound) |
+| `filters`   | Filter update events and subscriptions                            |
+| `variables` | Variable update events and subscriptions                          |
+| `all`       | Everything above                                                  |
 
 **Example output:**
 
@@ -1404,10 +1397,10 @@ domo.onDataUpdated((alias) => {
 
 The filter event name on the wire is `"filter"` (not `"filtersUpdated"`). Desktop and mobile use different field names which domo.js normalizes for you:
 
-| Field | Desktop | Mobile |
-| --- | --- | --- |
-| Column | `columnName` | `column` |
-| Operator | `operator` | `operand` |
+| Field    | Desktop      | Mobile    |
+| -------- | ------------ | --------- |
+| Column   | `columnName` | `column`  |
+| Operator | `operator`   | `operand` |
 
 ---
 

--- a/portal/Apps/App-Framework/Tools/domo-js.mdx
+++ b/portal/Apps/App-Framework/Tools/domo-js.mdx
@@ -18,7 +18,7 @@ domo.js (published as `ryuu.js`) is the official JavaScript SDK for building Cus
 
 | Feature | Description |
 | --- | --- |
-| `domo.broadcast()` | Topic-based cross-app communication with sticky replay and source identity |
+| `domo.broadcast()` | Channel-based cross-app communication with sticky replay and source identity |
 | `domo.intercept()` | Register request middleware — logging, retries, custom headers |
 | Structured errors | `DomoHttpError`, `DomoAuthError`, `DomoConnectionError`, `DomoValidationError`, `DomoTimeoutError` |
 | `RequestOptions.schema` | Runtime response validation with a custom parse function |
@@ -58,7 +58,7 @@ domo.onFiltersUpdated((filters) => {
 - **AI Services** — Text generation and text-to-SQL via Domo's AI Service Layer
 - **HTTP API Access** — Authenticated requests to Domo datasets, datastores, and APIs
 - **Real-time Events** — Listen for dataset updates, filter changes, and variable updates
-- **App Broadcasting** — Topic-based pub/sub between apps on the same page with sticky replay and source identity
+- **App Broadcasting** — Channel-based pub/sub between apps on the same page with sticky replay and source identity
 - **Filter Management** — Get and set page-level filters programmatically
 - **Variable Management** — Access and update page variables
 - **Custom App Data** — Send custom data between apps on the same page
@@ -881,8 +881,9 @@ Publish a message to all apps subscribed to the given channel on the same page.
 
 **Throws:**
 
-- `Error('Reserved namespace')` — Topic starts with `domo:`
+- `Error('Reserved namespace')` — Channel starts with `domo:`
 - `Error('Payload too large')` — Serialized payload exceeds 64 KB
+- `Error('Undeclared channel')` — Channel is not declared in `manifest.json` (Domo page only; Pro Code Editor logs a `console.warn()` instead)
 
 ```javascript
 // Fire-and-forget event
@@ -890,25 +891,6 @@ domo.broadcast('chart:hover', { seriesId: 'revenue', index: 3 });
 
 // Sticky state (retained for late subscribers)
 domo.broadcast('selection:changed', { id: 42, name: 'Acme Corp' }, { sticky: true });
-```
-
----
-
-#### `domo.broadcastState(channel, payload)`
-
-Shorthand for `domo.broadcast(channel, payload, { sticky: true })`. Use this when publishing state that late-mounting apps should receive immediately.
-
-**Parameters:**
-
-- `channel` (string, required) — Channel name
-- `payload` (unknown, required) — State value to broadcast and retain
-
-**Returns:** `void`
-
-```javascript
-// These are equivalent:
-domo.broadcastState('config:theme', { mode: 'dark' });
-domo.broadcast('config:theme', { mode: 'dark' }, { sticky: true });
 ```
 
 ---

--- a/portal/Apps/App-Framework/Tools/domo-js.mdx
+++ b/portal/Apps/App-Framework/Tools/domo-js.mdx
@@ -706,14 +706,14 @@ domo.onAppDataUpdated((data) => {
 **Use Case:** Enable communication between multiple Custom Apps on the same Domo page.
 
 <Note>
-**Note:** For new apps, prefer [App Broadcasting](#broadcasting) over `onAppDataUpdated`. Broadcasting provides topic-based routing, sticky replay, source identity, and manifest-declared channels.
+**Note:** For new apps, prefer [App Broadcasting](#broadcasting) over `onAppDataUpdated`. Broadcasting provides channel-based routing, sticky replay, source identity, and manifest-declared channels.
 </Note>
 
 ---
 
 #### Broadcasting
 
-The broadcasting methods provide a topic-based pub/sub system for cross-app communication. Apps publish named messages and subscribe to topics — the host routes messages between apps on the same page.
+The broadcasting methods provide a channel-based pub/sub system for cross-app communication. Apps publish named messages and subscribe to channels — the host routes messages between apps on the same page.
 
 <Note>
 **Note:** App Broadcasting requires the `app-broadcasting` feature switch. When disabled, all methods are safe no-ops with a one-time `console.warn`.
@@ -723,13 +723,13 @@ See the [App Broadcasting Guide](/portal/Apps/App-Framework/Guides/broadcasting)
 
 ---
 
-#### `domo.onBroadcast(topic, handler)`
+#### `domo.onBroadcast(channel, handler)`
 
-Subscribe to messages on a topic. If the topic is sticky and a value has already been published, the handler fires immediately with the last value.
+Subscribe to messages on a channel. If the channel is sticky and a value has already been published, the handler fires immediately with the last value.
 
 **Parameters:**
 
-- `topic` (string, required) — Topic name to subscribe to. Cannot start with `domo:`.
+- `channel` (string, required) — Channel name to subscribe to. Cannot start with `domo:`.
 - `handler` — `(msg: BroadcastMessage) => void`
 
 **Returns:** `function` — Unsubscribe function. Call it to stop listening.
@@ -738,7 +738,7 @@ Subscribe to messages on a topic. If the topic is sticky and a value has already
 
 ```typescript
 interface BroadcastMessage {
-  topic: string;       // Topic the message was published to
+  channel: string;     // Channel the message was published to
   payload: unknown;    // Data sent by the publisher
   sourceAppId: string; // Host-stamped app instance ID (trustworthy)
   timestamp: number;   // Host-assigned timestamp (ms since epoch)
@@ -757,13 +757,13 @@ unsubscribe();
 
 ---
 
-#### `domo.onBroadcastOnce(topic, handler)`
+#### `domo.onBroadcastOnce(channel, handler)`
 
-Subscribe to a topic and automatically unsubscribe after the first message is received.
+Subscribe to a channel and automatically unsubscribe after the first message is received.
 
 **Parameters:**
 
-- `topic` (string, required) — Topic name
+- `channel` (string, required) — Channel name
 - `handler` — `(msg: BroadcastMessage) => void`
 
 **Returns:** `function` — Unsubscribe function (can cancel before first delivery)
@@ -777,13 +777,13 @@ domo.onBroadcastOnce('init:ready', (msg) => {
 
 ---
 
-#### `domo.onBroadcastFrom(topic, sourceAppId, handler)`
+#### `domo.onBroadcastFrom(channel, sourceAppId, handler)`
 
-Subscribe to a topic but only receive messages from a specific app instance.
+Subscribe to a channel but only receive messages from a specific app instance.
 
 **Parameters:**
 
-- `topic` (string, required) — Topic name
+- `channel` (string, required) — Channel name
 - `sourceAppId` (string, required) — Only deliver messages from this app instance
 - `handler` — `(msg: BroadcastMessage) => void`
 
@@ -861,18 +861,18 @@ domo.requestAppDataUpdate({
 ```
 
 <Note>
-**Note:** For new apps, prefer [`domo.broadcast()`](#domo-broadcast-topic-payload-opts) over `requestAppDataUpdate`. Broadcasting provides topic routing, sticky state, and source identity.
+**Note:** For new apps, prefer [`domo.broadcast()`](#domo-broadcast-channel-payload-opts) over `requestAppDataUpdate`. Broadcasting provides channel routing, sticky state, and source identity.
 </Note>
 
 ---
 
-#### `domo.broadcast(topic, payload, opts?)`
+#### `domo.broadcast(channel, payload, opts?)`
 
-Publish a message to all apps subscribed to the given topic on the same page.
+Publish a message to all apps subscribed to the given channel on the same page.
 
 **Parameters:**
 
-- `topic` (string, required) — Topic name. Cannot start with `domo:`.
+- `channel` (string, required) — Channel name. Cannot start with `domo:`.
 - `payload` (unknown, required) — Any serializable data. Must be under 64 KB when serialized.
 - `opts` (object, optional):
   - `sticky` (boolean) — If `true`, the bus retains this value and replays it to future subscribers. Defaults to `false`.
@@ -894,13 +894,13 @@ domo.broadcast('selection:changed', { id: 42, name: 'Acme Corp' }, { sticky: tru
 
 ---
 
-#### `domo.broadcastState(topic, payload)`
+#### `domo.broadcastState(channel, payload)`
 
-Shorthand for `domo.broadcast(topic, payload, { sticky: true })`. Use this when publishing state that late-mounting apps should receive immediately.
+Shorthand for `domo.broadcast(channel, payload, { sticky: true })`. Use this when publishing state that late-mounting apps should receive immediately.
 
 **Parameters:**
 
-- `topic` (string, required) — Topic name
+- `channel` (string, required) — Channel name
 - `payload` (unknown, required) — State value to broadcast and retain
 
 **Returns:** `void`

--- a/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting.mdx
+++ b/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting.mdx
@@ -15,7 +15,7 @@ This tutorial builds two Custom Apps that communicate in real time using [App Br
 Along the way you'll learn:
 
 - How to declare broadcast channels in `manifest.json`
-- How to use `domo.broadcastState()` for sticky messages that survive late mounts
+- How to use `{ sticky: true }` for state that survives late mounts
 - How to filter messages by source using `domo.onBroadcastFrom()`
 - Best practices for channel naming and payload design
 
@@ -105,12 +105,12 @@ export default function App() {
     setSelectedId(customer.id);
 
     // Publish sticky state — late-mounting subscribers get this immediately
-    domo.broadcastState('selection:changed', {
+    domo.broadcast('selection:changed', {
       id: customer.id,
       name: customer.name,
       region: customer.region,
       revenue: customer.revenue,
-    });
+    }, { sticky: true });
   }
 
   return (
@@ -267,7 +267,7 @@ Real apps often use multiple channels. Here's a Selector App that publishes both
 
 ```javascript
 // Selection is sticky — persists for late subscribers
-domo.broadcastState('selection:changed', { id: row.id, name: row.name });
+domo.broadcast('selection:changed', { id: row.id, name: row.name }, { sticky: true });
 
 // Hover is ephemeral — only relevant right now
 domo.broadcast('chart:hover', { seriesId: 'revenue', index: 3 });
@@ -327,7 +327,7 @@ Rate-limit errors from the host arrive asynchronously. The SDK logs a warning wh
 | Concept | What you learned |
 | --- | --- |
 | `channels` in manifest | Declare what your app publishes and subscribes to |
-| `domo.broadcastState()` | Publish sticky state that late subscribers receive immediately |
+| `domo.broadcast()` | Publish a message; pass `{ sticky: true }` to retain it for late subscribers |
 | `domo.onBroadcast()` | Subscribe to a channel and react to messages |
 | `domo.onBroadcastFrom()` | Filter messages by source app |
 | `domo.onBroadcastOnce()` | Auto-unsubscribe after first delivery |

--- a/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting.mdx
+++ b/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting.mdx
@@ -7,20 +7,26 @@ description: Build two coordinated apps that communicate via App Broadcasting �
 
 ---
 
-This tutorial builds two Custom Apps that communicate in real time using [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting). You'll create:
+This tutorial builds two Custom Apps that talk to each other in real time using [App Broadcasting](/portal/Apps/App-Framework/Guides/broadcasting). You'll create:
 
-1. **Selector App** — A data table that publishes a `selection:changed` event whenever a user clicks a row
-2. **Detail App** — A panel that subscribes to `selection:changed` and displays details for the selected record
+1. **Selector App** — a data table that publishes a `selection:changed` message whenever a user clicks a row
+2. **Detail App** — a panel that subscribes to `selection:changed` and shows details for the selected record
 
-Along the way you'll learn:
+Along the way you'll learn how to:
 
-- How to declare broadcast channels in `manifest.json`
-- How to use `{ sticky: true }` for state that survives late mounts
-- How to filter messages by source using `domo.onBroadcastFrom()`
-- Best practices for channel naming and payload design
+- Declare broadcast channels in `manifest.json`
+- Publish and subscribe with `domo.broadcast()` and `domo.onBroadcast()`
+- Sync current state when an app mounts late (the bus keeps no history)
+- Filter messages by source with `domo.onBroadcastFrom()`
+
+```mermaid
+flowchart LR
+    S["Selector App<br/>publishes selection:changed"] -- selection:changed --> H{{Domo page}}
+    H -- selection:changed --> D["Detail App<br/>subscribes selection:changed"]
+```
 
 <Note>
-**Prerequisites:** Complete the [Setup and Installation](/portal/Apps/App-Framework/Quickstart/Setup-and-Installation) guide. You'll need two app designs published to the same Domo page.
+**Prerequisites:** Complete the [Setup and Installation](/portal/Apps/App-Framework/Quickstart/Setup-and-Installation) guide. You'll place both apps on the same Domo page, and the `app-broadcasting` feature switch must be enabled on your instance.
 </Note>
 
 ### Step 1: Scaffold both apps
@@ -63,18 +69,14 @@ Open `selector-app/manifest.json` and add the `channels` and `datasetsMapping` p
     "publishes": [
       {
         "name": "selection:changed",
-        "description": "Fires when the user clicks a customer row",
-        "sticky": true
+        "description": "Fires when the user clicks a customer row"
       }
     ]
   }
 }
 ```
 
-Key decisions:
-
-- **`sticky: true`** — The Detail App might mount after the user has already clicked a row. Sticky ensures it receives the last selection immediately.
-- **Channel naming** — `selection:changed` uses the `namespace:event` convention. The namespace groups related channels; the event describes what happened.
+The channel name `selection:changed` uses the `namespace:event` convention: the namespace groups related channels; the event describes what happened.
 
 ### Step 3: Build the Selector App component
 
@@ -98,19 +100,18 @@ export default function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   useEffect(() => {
-    domo.data.query('customers').then(setCustomers);
+    domo.get('/data/v1/customers').then(setCustomers);
   }, []);
 
   function handleRowClick(customer: Customer) {
     setSelectedId(customer.id);
 
-    // Publish sticky state — late-mounting subscribers get this immediately
     domo.broadcast('selection:changed', {
       id: customer.id,
       name: customer.name,
       region: customer.region,
       revenue: customer.revenue,
-    }, { sticky: true });
+    });
   }
 
   return (
@@ -165,7 +166,11 @@ Open `detail-app/manifest.json`:
 }
 ```
 
-The Detail App has no datasets of its own — it gets all its data from the Selector App's broadcast messages.
+The Detail App has no datasets of its own — it gets all its data from the Selector App's messages.
+
+<Note>
+**Note:** In production, an app receives a channel only if that channel is listed under `subscribes`. Declaring `selection:changed` here is what wires the Detail App up to receive it.
+</Note>
 
 ### Step 5: Build the Detail App component
 
@@ -218,7 +223,7 @@ export default function App() {
 }
 ```
 
-Because the Selector App publishes with `sticky: true`, if the Detail App mounts after a selection has been made, it immediately receives the last value — no waiting for the user to click again.
+`onBroadcast` returns an unsubscribe function — call it in the effect cleanup so the subscription is removed when the component unmounts.
 
 ### Step 6: Publish and test
 
@@ -231,13 +236,57 @@ cd selector-app && domo publish
 cd ../detail-app && domo publish
 ```
 
-In Domo, create a new App Studio page and add both apps as cards. Broadcasting happens automatically — you don't need to configure anything in the Wiring Screen for message routing, though the Wiring Screen will display the channel declarations from your manifests for visibility. Click a row in the Selector App — the Detail App updates instantly.
+In Domo, create a new App Studio page and add both apps as cards. Broadcasting happens automatically once both apps are on the same page — you don't configure any routing. Click a row in the Selector App, and the Detail App updates instantly.
+
+### Pattern: Sync current state on mount
+
+---
+
+The bus keeps no history, so if the Detail App mounts *after* a row was already selected, it starts empty until the next click. To catch up, have the Detail App **request** the current selection when it mounts, and have the Selector App **answer** by republishing.
+
+Add a request channel to both manifests — `subscribes` in the Selector, `publishes` in the Detail:
+
+```json
+// selector-app/manifest.json → channels
+"publishes":  [{ "name": "selection:changed", "description": "Row selection" }],
+"subscribes": [{ "name": "selection:request", "description": "Replay the current selection" }]
+```
+
+```json
+// detail-app/manifest.json → channels
+"subscribes": [{ "name": "selection:changed", "description": "Selected customer" }],
+"publishes":  [{ "name": "selection:request", "description": "Ask for the current selection" }]
+```
+
+In the Selector App, answer requests by republishing the last selection:
+
+```tsx
+const [selection, setSelection] = useState<CustomerPayload | null>(null);
+
+useEffect(() => {
+  return domo.onBroadcast('selection:request', () => {
+    if (selection) domo.broadcast('selection:changed', selection);
+  });
+}, [selection]);
+```
+
+In the Detail App, ask for the current selection right after subscribing:
+
+```tsx
+useEffect(() => {
+  const unsubscribe = domo.onBroadcast('selection:changed', (msg) =>
+    setCustomer(msg.payload as CustomerPayload),
+  );
+  domo.broadcast('selection:request', {}); // catch up on mount
+  return () => unsubscribe();
+}, []);
+```
 
 ### Pattern: Filtering by source
 
 ---
 
-If your page has multiple Selector Apps and you only want to listen to one, use `domo.onBroadcastFrom()`:
+If a page has multiple Selector Apps and you only want to listen to one, use `domo.onBroadcastFrom()`:
 
 ```javascript
 // Only react to messages from a specific app instance
@@ -246,40 +295,38 @@ domo.onBroadcastFrom('selection:changed', 'target-app-instance-id', (msg) => {
 });
 ```
 
-You can find an app's instance ID in the `sourceAppId` field of any message it sends, or in the App Broadcasting DevTools inspector.
+The instance ID is the `sourceAppId` on any message that app sends — it identifies a specific *card instance* on the page, so two copies of the same app have different IDs. Like `onBroadcast`, this returns an unsubscribe function.
+
+<Note>
+**Note:** A visual broadcasting inspector for viewing live channel traffic and instance IDs is on the roadmap. Until then, log `sourceAppId` during development to find an instance's ID.
+</Note>
 
 ### Pattern: Multi-channel coordination
 
 ---
 
-Real apps often use multiple channels. Here's a Selector App that publishes both selection state and hover events:
+Real apps often use several channels. Here's a Selector App that publishes both selection and hover events:
 
 ```json
 {
   "channels": {
     "publishes": [
-      { "name": "selection:changed", "description": "Row click", "sticky": true },
-      { "name": "chart:hover", "description": "Mouse hover on data point", "sticky": false }
+      { "name": "selection:changed", "description": "Row click" },
+      { "name": "chart:hover", "description": "Mouse hover on data point" }
     ]
   }
 }
 ```
 
 ```javascript
-// Selection is sticky — persists for late subscribers
-domo.broadcast('selection:changed', { id: row.id, name: row.name }, { sticky: true });
-
-// Hover is ephemeral — only relevant right now
+domo.broadcast('selection:changed', { id: row.id, name: row.name });
 domo.broadcast('chart:hover', { seriesId: 'revenue', index: 3 });
 ```
 
 The subscriber decides which channels it cares about:
 
 ```javascript
-// Subscribe to selection (sticky — gets last value immediately)
 domo.onBroadcast('selection:changed', (msg) => updateDetail(msg.payload));
-
-// Subscribe to hover (ephemeral — only fires in real time)
 domo.onBroadcast('chart:hover', (msg) => highlightPoint(msg.payload));
 ```
 
@@ -287,7 +334,7 @@ domo.onBroadcast('chart:hover', (msg) => highlightPoint(msg.payload));
 
 ---
 
-Use `domo.onBroadcastOnce()` when an app only needs to receive a message once (e.g., initial configuration from a coordinator app):
+Use `domo.onBroadcastOnce()` when an app only needs a message once — for example, an initial configuration from a coordinator app. It unsubscribes automatically after the first delivery:
 
 ```javascript
 domo.onBroadcastOnce('config:init', (msg) => {
@@ -300,41 +347,29 @@ domo.onBroadcastOnce('config:init', (msg) => {
 
 ---
 
-The SDK throws synchronous errors for invalid usage:
+`domo.broadcast()` returns immediately and **never throws**. If the host rejects a message — a reserved `domo:` channel, a payload over 64 KB, more than 100 messages per second, or the feature switch being off — it notifies only the sending app, and the SDK writes a warning to the browser console:
 
-```javascript
-try {
-  // Reserved namespace — throws immediately
-  domo.broadcast('domo:system', { data: 'test' });
-} catch (e) {
-  console.error(e.message); // "Reserved namespace"
-}
-
-try {
-  // Payload too large — throws immediately
-  domo.broadcast('data:export', hugeObject);
-} catch (e) {
-  console.error(e.message); // "Payload too large"
-}
+```
+[domo.broadcast] RATE_LIMIT_EXCEEDED — Rate limit of 100 messages/second exceeded (channel: chart:hover)
 ```
 
-Rate-limit errors from the host arrive asynchronously. The SDK logs a warning when messages are being throttled.
+Because there's no thrown error to catch, watch the console during development, and design publishers to stay within the limits (for example, throttle high-frequency events like hover before broadcasting).
 
 ### Summary
 
 ---
 
-| Concept | What you learned |
-| --- | --- |
-| `channels` in manifest | Declare what your app publishes and subscribes to |
-| `domo.broadcast()` | Publish a message; pass `{ sticky: true }` to retain it for late subscribers |
-| `domo.onBroadcast()` | Subscribe to a channel and react to messages |
-| `domo.onBroadcastFrom()` | Filter messages by source app |
-| `domo.onBroadcastOnce()` | Auto-unsubscribe after first delivery |
-| Sticky vs. ephemeral | Use sticky for state, ephemeral for events |
+| Concept                  | What you learned                                                                                |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `channels` in manifest   | Declare what your app publishes and subscribes to; `subscribes` is what wires you up to receive |
+| `domo.broadcast()`       | Publish a message to a channel; returns `void`, never throws                                    |
+| `domo.onBroadcast()`     | Subscribe to a channel; returns an unsubscribe function                                         |
+| `domo.onBroadcastFrom()` | Only receive messages from a specific app instance                                              |
+| `domo.onBroadcastOnce()` | Auto-unsubscribe after the first message                                                        |
+| Sync on mount            | The bus keeps no history — request current state instead of relying on replay                   |
 
 ### Next steps
 
-- [App Broadcasting Guide](/portal/Apps/App-Framework/Guides/broadcasting) — Architecture, security model, and lifecycle details
+- [App Broadcasting Guide](/portal/Apps/App-Framework/Guides/broadcasting) — Architecture, limits, and lifecycle
 - [The Manifest File](/portal/Apps/App-Framework/Guides/manifest#channels) — Full channel declaration reference
 - [domo.js SDK Reference](/portal/Apps/App-Framework/Tools/domo-js#broadcasting) — Complete API documentation

--- a/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting.mdx
+++ b/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting.mdx
@@ -17,7 +17,7 @@ Along the way you'll learn:
 - How to declare broadcast channels in `manifest.json`
 - How to use `domo.broadcastState()` for sticky messages that survive late mounts
 - How to filter messages by source using `domo.onBroadcastFrom()`
-- Best practices for topic naming and payload design
+- Best practices for channel naming and payload design
 
 <Note>
 **Prerequisites:** Complete the [Setup and Installation](/portal/Apps/App-Framework/Quickstart/Setup-and-Installation) guide. You'll need two app designs published to the same Domo page.
@@ -74,7 +74,7 @@ Open `selector-app/manifest.json` and add the `channels` and `datasetsMapping` p
 Key decisions:
 
 - **`sticky: true`** — The Detail App might mount after the user has already clicked a row. Sticky ensures it receives the last selection immediately.
-- **Topic naming** — `selection:changed` uses the `namespace:event` convention. The namespace groups related topics; the event describes what happened.
+- **Channel naming** — `selection:changed` uses the `namespace:event` convention. The namespace groups related channels; the event describes what happened.
 
 ### Step 3: Build the Selector App component
 
@@ -224,14 +224,14 @@ Because the Selector App publishes with `sticky: true`, if the Detail App mounts
 
 ---
 
-Publish both apps and place them on the same Domo page:
+Publish both apps and place them on the same App Studio page:
 
 ```bash
 cd selector-app && domo publish
 cd ../detail-app && domo publish
 ```
 
-Create a new Dashboard in Domo and add both apps as cards. Click a row in the Selector App — the Detail App updates instantly.
+In Domo, create a new App Studio page and add both apps as cards. Broadcasting happens automatically — you don't need to configure anything in the Wiring Screen for message routing, though the Wiring Screen will display the channel declarations from your manifests for visibility. Click a row in the Selector App — the Detail App updates instantly.
 
 ### Pattern: Filtering by source
 
@@ -248,11 +248,11 @@ domo.onBroadcastFrom('selection:changed', 'target-app-instance-id', (msg) => {
 
 You can find an app's instance ID in the `sourceAppId` field of any message it sends, or in the App Broadcasting DevTools inspector.
 
-### Pattern: Multi-topic coordination
+### Pattern: Multi-channel coordination
 
 ---
 
-Real apps often use multiple topics. Here's a Selector App that publishes both selection state and hover events:
+Real apps often use multiple channels. Here's a Selector App that publishes both selection state and hover events:
 
 ```json
 {
@@ -273,7 +273,7 @@ domo.broadcastState('selection:changed', { id: row.id, name: row.name });
 domo.broadcast('chart:hover', { seriesId: 'revenue', index: 3 });
 ```
 
-The subscriber decides which topics it cares about:
+The subscriber decides which channels it cares about:
 
 ```javascript
 // Subscribe to selection (sticky — gets last value immediately)
@@ -328,7 +328,7 @@ Rate-limit errors from the host arrive asynchronously. The SDK logs a warning wh
 | --- | --- |
 | `channels` in manifest | Declare what your app publishes and subscribes to |
 | `domo.broadcastState()` | Publish sticky state that late subscribers receive immediately |
-| `domo.onBroadcast()` | Subscribe to a topic and react to messages |
+| `domo.onBroadcast()` | Subscribe to a channel and react to messages |
 | `domo.onBroadcastFrom()` | Filter messages by source app |
 | `domo.onBroadcastOnce()` | Auto-unsubscribe after first delivery |
 | Sticky vs. ephemeral | Use sticky for state, ephemeral for events |


### PR DESCRIPTION
## Summary

Reconciles the **App Broadcasting** developer docs with the shipped implementation, cross-referenced against `DomoWeb`@master (`PageBus`, `DomoAppController`) and `ryuu.js`@master (`domo.js/src/broadcast.ts`). The existing docs described an earlier/aspirational design; several documented features do not exist in code.

Files:
- `portal/Apps/App-Framework/Guides/broadcasting.mdx` — full rewrite + Mermaid architecture & sequence diagrams
- `portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting.mdx` — rewrite; flow diagram + request/reply state-sync pattern
- `portal/Apps/App-Framework/Tools/domo-js.mdx` — SDK reference corrected
- `portal/Apps/App-Framework/Guides/manifest.mdx` — `channels` schema corrected
- `portal/Apps/App-Framework/Guides/overview.mdx` — terminology + sticky removed

## Corrections (code-verified)

- **Sticky removed entirely** — the host `PageBus` never retained/replayed values; the SDK `sticky` flag is being removed. Bus is documented as fire-and-forget.
- **`broadcast()` never throws** — removed the fictional `Throws:` block and all `try/catch` examples. Host rejections return asynchronously and surface as `console.warn('[domo.broadcast] CODE — …')` (`RESERVED_NAMESPACE`, `PAYLOAD_TOO_LARGE`, `PAYLOAD_NOT_SERIALIZABLE`, `RATE_LIMIT_EXCEEDED`, `FEATURE_DISABLED`).
- **Removed fictional duplicate filtering.**
- **Limits/enforcement corrected** — 100 msg/s is a hardcoded per-app constant (not admin-configurable); 64 KB payload cap and reserved `domo:` namespace are host-side; production (`off` mode) does **not** reject undeclared channels.
- **Subscription model** — manifest-driven auto-subscribe (you receive a channel only if it's declared under `subscribes`); **publisher never receives its own message**.
- **Message shape** — `sourceAppId` is the publishing **card instance** id (host-stamped, unspoofable); `timestamp` is host-assigned at delivery.
- **Manifest `channels` schema** — `description` is optional (was "Required"); dropped inert `sticky` and the `schema` footgun; added real validator limits (≤100 channels/direction, name ≤256 chars, unique names); removed the non-existent "WIDE mode".
- **DevTools** — no inspector/validator exists yet; replaced prior claims with a single "on the roadmap" note.

## Added
- Mermaid **architecture** and **publish/deliver sequence** diagrams (guide) and a two-app **flow** diagram (tutorial).
- A **request/reply state-sync-on-mount** pattern replacing the removed sticky behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)