### PR TITLE
docs: add v2.16.0 release notes

### DIFF
--- a/releaseNotes/v2.16.0.mdx
+++ b/releaseNotes/v2.16.0.mdx
@@ -1,0 +1,53 @@
+---
+title: "Domo Documentation Hub v2.16.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.16.0 of the Domo Documentation Hub is now available! This release is a big one for connectors — a huge expansion of writeback documentation and several new connector articles — alongside a rebuilt App Framework broadcasting guide, fresh microlearning videos, and more localized Japanese content. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🔌 Connector Documentation Expansion
+
+This release brings the most substantial connector update in a while. The writeback connector reference has grown by more than 130 entries, giving admins a single, comprehensive list of every writeback connector Domo supports and its connector ID. See the fully expanded [list of writeback connectors](https://www.domo.com/docs/s/article/000005353).
+
+We also added and improved several individual connector articles:
+
+- A brand-new [Humanity Connector](https://www.domo.com/docs/s/article/Humanity-Connector) article covering setup and configuration.
+- A new [Google BigQuery Rakuten Custom Unload Connector](https://www.domo.com/docs/s/article/4407975319959) article.
+- The [Google Ad Manager REST Connector](https://www.domo.com/docs/s/article/000006016) now documents a second authentication method — Google Ad Manager Service — with a step-by-step guide to creating a Service Account Key JSON.
+- The [Microsoft OneDrive Business Connector](https://www.domo.com/docs/s/article/360043436753) gained a details section listing the reports it returns.
+- A new [Microsoft Azure Data Lake Store Connector – Deprecated](https://www.domo.com/docs/s/article/000003928) article to flag the connector's deprecated status for customers still referencing it.
+
+Thanks to Arun Raj for driving the writeback expansion and the connector article updates, and to Jared Peterson for the Rakuten and Azure Data Lake Store articles.
+
+### 🧩 App Framework: Cross-App Broadcasting Overhaul
+
+The Cross-App Broadcasting documentation was reconciled with the shipped DomoWeb and ryuu.js code so developers can rely on it being accurate. The guide now uses "channel" consistently in place of "topic," removes the deprecated `broadcastState`, and clarifies enforcement and message-bus behavior. Read the updated [broadcasting guide](https://www.domo.com/docs/portal/Apps/App-Framework/Guides/broadcasting), the refreshed [domo.js reference](https://www.domo.com/docs/portal/Apps/App-Framework/Tools/domo-js), and the revised [Cross-App Broadcasting React tutorial](https://www.domo.com/docs/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting).
+
+Thanks to Jason Hansen for aligning these docs with the real code.
+
+### 🎬 New Microlearning Videos
+
+The [Domo Video Library](https://www.domo.com/docs/s/article/Domo-Video-Library) picked up eight new microlearning videos, including a Code Engine overview, Domo x Snowflake Cortex AI, Domo and Databricks working together, Domo powering Gemini Enterprise with BigQuery connectors, and overview videos for Cloud Integrations, Connectors, Data Integration, and Domo Apps.
+
+Thanks to the automated video library sync for keeping this current.
+
+### 🌏 Expanded Japanese Localization
+
+We continued translating high-priority content into Japanese, adding articles across the June batches — including the AI Library, connecting AI tools to Domo with MCP, AI Model Version Differences, Domo on Lakebase, using Worksheets, the Getting Started guides for data consumers and data engineers, several connector articles, and a restored Heat Map article. The Japanese AI section was also realigned with the English navigation.
+
+Thanks to Masaaki for the translations, Jared Peterson for the nav and formatting work, and Bradley Turek for restoring the Japanese Heat Map article.
+
+### 🛠️ Fixes & Polish
+
+A handful of accuracy and rendering fixes landed as well: the [SCIM in Domo](https://www.domo.com/docs/s/article/000005241) article had its custom-attributes and email external-name details corrected, and the DomoEmbed snippet's React import warning was fixed with a live example added to the style guide.
+
+Thanks to jkreitzman for the SCIM corrections and Bradley Turek for the DomoEmbed fix.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who contributed to this release — your work makes the knowledge base more complete and more trustworthy for every reader.
+
+If you have questions or feedback, please reach out — we're always happy to help!

--- a/releaseNotesExternal/v2.16.0.mdx
+++ b/releaseNotesExternal/v2.16.0.mdx
@@ -1,0 +1,43 @@
+---
+title: "Domo Documentation Hub v2.16.0 Release Notes"
+---
+
+Hello everyone!
+
+We're excited to announce that version 2.16.0 of the Domo Documentation Hub is now available! This release is a big one for connectors — a huge expansion of writeback documentation and several new connector articles — alongside a rebuilt App Framework broadcasting guide, fresh microlearning videos, and more localized Japanese content. You can view these changes in our knowledge base at [www.domo.com/docs](https://www.domo.com/docs).
+
+## 🌟 What's New
+
+### 🔌 Connector Documentation Expansion
+
+This release brings the most substantial connector update in a while. The writeback connector reference has grown by more than 130 entries, giving admins a single, comprehensive list of every writeback connector Domo supports and its connector ID. See the fully expanded [list of writeback connectors](https://www.domo.com/docs/s/article/000005353).
+
+We also added and improved several individual connector articles:
+
+- A brand-new [Humanity Connector](https://www.domo.com/docs/s/article/Humanity-Connector) article covering setup and configuration.
+- A new [Google BigQuery Rakuten Custom Unload Connector](https://www.domo.com/docs/s/article/4407975319959) article.
+- The [Google Ad Manager REST Connector](https://www.domo.com/docs/s/article/000006016) now documents a second authentication method — Google Ad Manager Service — with a step-by-step guide to creating a Service Account Key JSON.
+- The [Microsoft OneDrive Business Connector](https://www.domo.com/docs/s/article/360043436753) gained a details section listing the reports it returns.
+- A new [Microsoft Azure Data Lake Store Connector – Deprecated](https://www.domo.com/docs/s/article/000003928) article to flag the connector's deprecated status for customers still referencing it.
+
+### 🧩 App Framework: Cross-App Broadcasting Overhaul
+
+The Cross-App Broadcasting documentation was reconciled with the shipped DomoWeb and ryuu.js code so developers can rely on it being accurate. The guide now uses "channel" consistently in place of "topic," removes the deprecated `broadcastState`, and clarifies enforcement and message-bus behavior. Read the updated [broadcasting guide](https://www.domo.com/docs/portal/Apps/App-Framework/Guides/broadcasting), the refreshed [domo.js reference](https://www.domo.com/docs/portal/Apps/App-Framework/Tools/domo-js), and the revised [Cross-App Broadcasting React tutorial](https://www.domo.com/docs/portal/Apps/App-Framework/Tutorials/React/Cross-App-Broadcasting).
+
+### 🎬 New Microlearning Videos
+
+The [Domo Video Library](https://www.domo.com/docs/s/article/Domo-Video-Library) picked up eight new microlearning videos, including a Code Engine overview, Domo x Snowflake Cortex AI, Domo and Databricks working together, Domo powering Gemini Enterprise with BigQuery connectors, and overview videos for Cloud Integrations, Connectors, Data Integration, and Domo Apps.
+
+### 🌏 Expanded Japanese Localization
+
+We continued translating high-priority content into Japanese, adding articles across the June batches — including the AI Library, connecting AI tools to Domo with MCP, AI Model Version Differences, Domo on Lakebase, using Worksheets, the Getting Started guides for data consumers and data engineers, several connector articles, and a restored Heat Map article. The Japanese AI section was also realigned with the English navigation.
+
+### 🛠️ Fixes & Polish
+
+The [SCIM in Domo](https://www.domo.com/docs/s/article/000005241) article had its custom-attributes and email external-name details corrected for accuracy.
+
+## 🙏 Thank You
+
+A heartfelt thank you to everyone who helped make this release possible — your work makes the knowledge base more complete and more trustworthy for every reader.
+
+If you have questions or feedback, please reach out — we're always happy to help!


### PR DESCRIPTION
## Summary
- Adds internal release notes to `releaseNotes/v2.16.0.mdx`
- Adds sanitized external release notes to `releaseNotesExternal/v2.16.0.mdx`

Diff range `v2.15.0..v2.16.0` (spans the `v2.15.1` patch). Themes: connector documentation expansion (130+ writeback connectors, new Humanity/Rakuten/Azure Data Lake Store articles, Google Ad Manager REST + OneDrive Business updates), App Framework Cross-App Broadcasting overhaul, 8 new microlearning videos, expanded Japanese localization, and SCIM/DomoEmbed fixes.

## Test plan
- [x] Verify both files render correctly on the Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)