### PR TITLE
Document AppDB flat-payload auto-wrap, v1 + v2 (DOMO-494039)

### DIFF
--- a/openapi/framework/appdb.yaml
+++ b/openapi/framework/appdb.yaml
@@ -145,23 +145,26 @@ components:
 
     DocumentCreate:
       type: object
-      required:
-        - content
       properties:
         content:
           type: object
           additionalProperties: true
-          description: The document content matching collection schema
+          description: >-
+            The document content. If the request body has no `content` key, its
+            top-level fields are wrapped as the content automatically. For
+            example, `{"name": "Harry"}` is stored as `{"content": {"name":
+            "Harry"}}`.
 
     DocumentUpdate:
       type: object
-      required:
-        - content
       properties:
         content:
           type: object
           additionalProperties: true
-          description: Updated document content
+          description: >-
+            The replacement document content. If the request body has no
+            `content` key, its top-level fields are wrapped as the content
+            automatically.
 
     Collection:
       type: object
@@ -332,7 +335,10 @@ paths:
     post:
       x-excluded: true
       summary: Create Document (v1)
-      description: Creates a single document in a collection.
+      description: |-
+        Creates a single document in a collection.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
       - AppDB API
       parameters:
@@ -585,7 +591,10 @@ paths:
     put:
       x-excluded: true
       summary: Update Document (v1)
-      description: Updates an existing document in a collection.
+      description: |-
+        Updates an existing document in a collection.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
       - AppDB API
       parameters:
@@ -1126,7 +1135,10 @@ paths:
     post:
       x-excluded: true
       summary: Create Documents in Bulk (v1)
-      description: Create multiple documents in a given collection in a single HTTP request. Each document is limited to 2 MB.
+      description: |-
+        Create multiple documents in a given collection in a single HTTP request. Each document is limited to 2 MB.
+
+        Each entry accepts either the wrapped form `{"content": {...}}` or a flat object. A flat entry is stored under the `content` key automatically.
       tags:
       - AppDB API
       parameters:
@@ -1202,7 +1214,10 @@ paths:
     put:
       x-excluded: true
       summary: Upsert Documents in Bulk (v1)
-      description: "Update existing documents or create new ones in bulk. Documents with a matching `id` are updated; documents without a matching `id` are created. Each document is limited to 2 MB."
+      description: |-
+        Update existing documents or create new ones in bulk. Documents with a matching `id` are updated; documents without a matching `id` are created. Each document is limited to 2 MB.
+
+        To update an existing document, send its `id` alongside a `content` object. An entry with no `content` key is always treated as a new document: its top-level fields are wrapped under the `content` key automatically, and a top-level `id` is wrapped in with them rather than used to match an existing document. Use the wrapped `{"id": "...", "content": {...}}` form whenever you intend to update.
       tags:
       - AppDB API
       parameters:
@@ -1365,7 +1380,10 @@ paths:
   /domo/datastores/v2/collections/{collectionName}/documents:
     post:
       summary: Create Document
-      description: "Creates a single document in a collection."
+      description: |-
+        Creates a single document in a collection.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
       - AppDB API
       parameters:
@@ -1682,7 +1700,10 @@ paths:
 
     put:
       summary: Replace Document
-      description: "Replaces an existing document in a collection — the entire `content` object is overwritten with whatever you send. To update individual fields without replacing the whole document, use Partially Update Documents instead."
+      description: |-
+        Replaces an existing document in a collection — the entire `content` object is overwritten with whatever you send. To update individual fields without replacing the whole document, use Partially Update Documents instead.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
       - AppDB API
       parameters:
@@ -2397,7 +2418,10 @@ paths:
   /domo/datastores/v2/collections/{collectionName}/documents/bulk:
     post:
       summary: Create Documents in Bulk
-      description: "Create multiple documents in a given collection in a single HTTP request. Each document is limited to 2 MB."
+      description: |-
+        Create multiple documents in a given collection in a single HTTP request. Each document is limited to 2 MB.
+
+        Each entry accepts either the wrapped form `{"content": {...}}` or a flat object. A flat entry is stored under the `content` key automatically.
       tags:
       - AppDB API
       parameters:
@@ -2513,7 +2537,10 @@ paths:
 
     put:
       summary: Upsert Documents in Bulk
-      description: "Update existing documents or create new ones in bulk. Documents with a matching `id` are updated; documents without a matching `id` are created. Each document is limited to 2 MB."
+      description: |-
+        Update existing documents or create new ones in bulk. Documents with a matching `id` are updated; documents without a matching `id` are created. Each document is limited to 2 MB.
+
+        To update an existing document, send its `id` alongside a `content` object. An entry with no `content` key is always treated as a new document: its top-level fields are wrapped under the `content` key automatically, and a top-level `id` is wrapped in with them rather than used to match an existing document. Use the wrapped `{"id": "...", "content": {...}}` form whenever you intend to update.
       tags:
       - AppDB API
       parameters:

--- a/openapi/product/appdb.yaml
+++ b/openapi/product/appdb.yaml
@@ -77,7 +77,7 @@ components:
         content:
           type: object
           additionalProperties: true
-          description: "Arbitrary JSON content of the document. If omitted, the document is created with an empty content object."
+          description: "Arbitrary JSON content of the document. If the request body has no `content` key, its top-level fields are wrapped as the content automatically. For example, `{\"username\": \"Bill\"}` is stored as `{\"content\": {\"username\": \"Bill\"}}`."
 
     #========= RESPONSE SCHEMAS =========
     Document:
@@ -1161,7 +1161,10 @@ paths:
     post:
       summary: Create Document (v1, Deprecated)
       deprecated: true
-      description: "**Deprecated.** Use the v2 Create Document endpoint instead. Add a new document to a specified collection."
+      description: |-
+        **Deprecated.** Use the v2 Create Document endpoint instead. Add a new document to a specified collection.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
         - App DB API (Product)
       parameters:
@@ -1226,7 +1229,10 @@ paths:
     put:
       summary: Update Document (v1, Deprecated)
       deprecated: true
-      description: "**Deprecated.** Use the v2 Update Document endpoint instead. Modify an existing document in a collection."
+      description: |-
+        **Deprecated.** Use the v2 Update Document endpoint instead. Modify an existing document in a collection.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
         - App DB API (Product)
       parameters:
@@ -1626,7 +1632,10 @@ paths:
           $ref: '#/components/responses/CollectionNotFound'
     post:
       summary: Create Document
-      description: Add a new document to a specified collection.
+      description: |-
+        Add a new document to a specified collection.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
         - App DB API (Product)
       parameters:
@@ -1711,7 +1720,10 @@ paths:
 
     put:
       summary: Replace Document
-      description: "Replaces an existing document in a collection — the entire `content` object is overwritten with whatever you send. To update individual fields without replacing the whole document, use the Partially Update Documents endpoint instead."
+      description: |-
+        Replaces an existing document in a collection — the entire `content` object is overwritten with whatever you send. To update individual fields without replacing the whole document, use the Partially Update Documents endpoint instead.
+
+        The request body accepts either the wrapped form `{"content": {...}}` or a flat object. A flat payload is stored under the `content` key automatically.
       tags:
         - App DB API (Product)
       parameters:
@@ -1819,7 +1831,10 @@ paths:
   /api/datastores/v2/collections/{collectionId}/documents/bulk:
     post:
       summary: Bulk Create Documents
-      description: "Add multiple documents to a collection in a single request. Each document is limited to 2 MB."
+      description: |-
+        Add multiple documents to a collection in a single request. Each document is limited to 2 MB.
+
+        Each entry accepts either the wrapped form `{"content": {...}}` or a flat object. A flat entry is stored under the `content` key automatically.
       tags:
         - App DB API (Product)
       parameters:
@@ -1857,7 +1872,10 @@ paths:
           $ref: '#/components/responses/CollectionNotFound'
     put:
       summary: Bulk Upsert Documents
-      description: "Insert or update multiple documents in a single request. Documents with a matching `id` are updated; documents without a matching `id` are created. Each document is limited to 2 MB."
+      description: |-
+        Insert or update multiple documents in a single request. Documents with a matching `id` are updated; documents without a matching `id` are created. Each document is limited to 2 MB.
+
+        To update an existing document, send its `id` alongside a `content` object. An entry with no `content` key is always treated as a new document: its top-level fields are wrapped under the `content` key automatically, and a top-level `id` is wrapped in with them rather than used to match an existing document. Use the wrapped `{"id": "...", "content": {...}}` form whenever you intend to update.
       tags:
         - App DB API (Product)
       parameters:


### PR DESCRIPTION
## What this documents

Backend DOMO-494039 (magnum `26a525c2f`) makes AppDB **auto-wrap a flat JSON request body under `content`** — `{"name":"Harry"}` is stored as `{"content":{"name":"Harry"}}`. The wrapped form still works; non-object JSON (arrays, strings, numbers) is rejected. The deserializer is server-side and shared, so the behavior is identical across **v1 and v2** and across both the App Framework proxy paths (`/domo/datastores/...`) and the Product API paths (`/api/datastores/...`).

## Changes

**`openapi/framework/appdb.yaml`**
- Wrap note added to the v2 write ops: Create Document, Replace Document, Create Documents in Bulk, Upsert Documents in Bulk.
- Same note added to the `x-excluded` v1 write ops (not rendered on the site, but the raw spec can be referenced directly).
- Dropped `required: content` on `DocumentCreate` / `DocumentUpdate` and documented the wrap on their `content` fields.

**`openapi/product/appdb.yaml`**
- Wrap note added to the v2 write ops: Create Document, Replace Document, Bulk Create Documents, Bulk Upsert Documents.
- Same note added to the `deprecated` (still-rendered) v1 Create / Update ops.
- Updated the `DocumentContent.content` description.

Bulk Upsert keeps the tested caveat: a flat entry with no `content` key is always treated as a **new** document (a top-level `id` is wrapped in, not used to match) — use the wrapped `{"id":"...","content":{...}}` form to update.

## Stacking

Stacked on #431 (App Framework AppDB Doc Update). Base branch is `bradley.turek/appdb-consolidated`, so this PR's diff shows only the auto-wrap change. #431 is the bottom of the stack and must merge to `main` first; GitHub re-targets this PR's base to `main` after #431 lands.

## When to merge — HOLD

Do **not** merge on the normal weekly cadence. This documents a backend change with **no feature switch**; it rides the `2026-08-11` release branch and reaches production **~Sept 10, 2026**.

1. Merge **#431** to `main` first.
2. Keep this PR in **draft** until the `2026-08-11` release is in production.
3. Target the **Sept 14, 2026** KB release (PR marked ready by the preceding Thursday).

Publishing earlier would document behavior that isn't in production yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
