### PR TITLE
Update AI FAQ prompt-injection answer to match whitepaper

### DIFF
--- a/s/article/Domo-AI-FAQ.mdx
+++ b/s/article/Domo-AI-FAQ.mdx
@@ -20,7 +20,7 @@ This article answers common questions about how Domo's AI engine processes data,
   </Accordion>
 
   <Accordion title="Does the solution implement technical controls to mitigate prompt injection attacks?">
-    In addition to protections built into the models, Domo implements additional guardrails to help mitigate prompt injection attacks. However, prompt injection remains a risk. Domo recommends that customers take care when configuring custom agents with additional capabilities that could allow an agent to perform an action based on injected instructions.
+    In addition to protections built into the models, Domo implements additional guardrails to help mitigate prompt injection. Prompt injection nonetheless remains an industry-wide risk, so Domo recommends customers take care when configuring custom agents within Domo or via integrations with additional tools or capabilities that could let an agent act on injected instructions. Prompt-injection protection is a shared responsibility. Domo provides guardrails and always enforces the user permission and PDP boundaries described above, while customers configure each agent's instructions, tools, and human-in-the-loop checkpoints to match their risk tolerance. Domo does not provide a single, unified guardrail framework that universally governs every AI interaction.
   </Accordion>
 
   <Accordion title="Are prompts, inputs, embeddings, or outputs stored by the solution or any third-party provider?">


### PR DESCRIPTION
## What

Updates the prompt-injection answer in the **Domo AI FAQ** (`s/article/Domo-AI-FAQ.mdx`) to match the wording in Paul Conover's draft *AI Security and Privacy Whitepaper 2026*, so the public KB and the whitepaper answer the same question consistently.

## Why

Doug Zagami flagged that the public AI FAQ and the draft whitepaper answered the prompt-injection question differently, which affects what we can point customers to. Ken Boyer (PM) approved bringing the public FAQ in line with the more accurate whitepaper wording.

## Change

The answer to *"Does the solution implement technical controls to mitigate prompt injection attacks?"* now adds three points the public FAQ was missing:

1. Prompt-injection protection is a **shared responsibility**.
2. Domo provides guardrails and always enforces the user permission and PDP boundaries, while customers configure each agent's instructions, tools, and human-in-the-loop checkpoints.
3. Domo does not provide a single, unified guardrail framework that universally governs every AI interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)