### PR TITLE
Fix missing comma in docs.json navigation array

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -554,7 +554,7 @@
                           "s/article/360043435653",
                           "s/article/360042926474",
                           "s/article/360043430913",
-                          "s/article/Brivo-Connector"
+                          "s/article/Brivo-Connector",
                           "s/article/360043432513",
                           "s/article/360043432533",
                           "s/article/360043435353",


### PR DESCRIPTION
## Problem

Mintlify failed to build with:

```
Unable to parse docs.json file: SyntaxError: Expected ',' or ']' after array element in JSON at position 24487 (line 558 column 27)
```

The `"s/article/Brivo-Connector"` entry in the "Data Providers A-B" pages array was missing a trailing comma, producing invalid JSON.

## Fix

Add the missing comma after `"s/article/Brivo-Connector"`. Validated that `docs.json` now parses as valid JSON.

## Notes

This was hotfixed directly into `release/v2.17.0`; this PR mirrors the same one-line fix into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)