### PR TITLE
Add BigQuery Job User to read-only role requirements

### DIFF
--- a/s/article/000005237.mdx
+++ b/s/article/000005237.mdx
@@ -33,8 +33,14 @@ The BigQuery service account must have the following roles.
 
 **Read-only integration**
 
-- Roles: BigQuery Data Viewer
-- No additional permissions are required for read-only access.
+- Roles:
+    - BigQuery Data Viewer
+    - BigQuery Job User
+    - Service Account Token Creator (only if using WIF)
+- Additional permissions:
+    - `bigquery.jobs.create`
+
+<Note>**Note:** BigQuery Job User is required for a read-only integration, not only for writeback. When you create the integration, Domo validates the connection by running a query, and BigQuery runs every query inside a job—so the service account must be able to create jobs. Grant these roles on the project you enter as the **Project ID**.</Note>
 
 **Writeback and native transform**
 
@@ -150,7 +156,8 @@ The name can be changed later.
 1. Enter a name to identify the BigQuery service account in Domo.
 The name can be changed later.
 
-2. Enter the **Project ID** where you created your service account.
+2. Enter the **Project ID** of the project you want Domo to run queries in.
+Domo runs every query as a BigQuery job in this project, and BigQuery bills the job there, so the service account must hold the BigQuery Job User role on it. This is usually the project that contains your service account and your data. See [Roles and Permissions](#roles-and-permissions).
 
 3. Upload the JSON configuration file you downloaded from the Google Cloud Console.
 
@@ -298,3 +305,22 @@ No, spaces are not allowed in table names.
 </Accordion>
 
 </AccordionGroup>
+
+## Troubleshoot
+
+### Resolve a Job Creation Permission Error
+
+When you create the integration, Domo returns this error if the service account cannot create jobs in the project you entered as the **Project ID**:
+
+```text
+Access Denied: Project project-id: User does not have bigquery.jobs.create permission in project project-id.
+```
+
+Grant the service account the BigQuery Job User role on that project, then create the integration again. See [Roles and Permissions](#roles-and-permissions).
+
+Two things to check if you already granted the role:
+
+- **Confirm you granted it on the right project.** BigQuery checks this permission in the project that runs the query, which is the project you enter as the **Project ID**—not a project that only stores the data.
+- **Confirm the role is on the service account Domo uses.** If you authenticate with Workload Identity Federation, Domo impersonates the service account named in your JSON configuration file, and that service account needs the role.
+
+If your security policy does not allow the service account to hold job-creation rights permanently, you can grant BigQuery Job User, create the integration, and then revoke the role. The integration continues to read data, but automated data freshness checks stop working, because those also run queries.


### PR DESCRIPTION
Fixes an error in the **Roles and Permissions** section of *Connect Domo to Google BigQuery* (`s/article/000005237.mdx`). Raised by a support escalation where a customer followed the documented read-only role list and could not create the integration.

## The problem

The read-only role list said:

> Roles: BigQuery Data Viewer
> No additional permissions are required for read-only access.

That role set can never create a working BigQuery integration. When Domo creates the integration it validates the connection by running a query, and BigQuery runs every query inside a job — so `bigquery.jobs.create` (BigQuery Job User) is required before the integration can be created at all, read-only or not. The article listed Job User only under **Writeback and native transform**, so anyone setting up a read-only integration from these instructions hits an access-denied error.

This is expected product behavior, not a bug, so the documentation is what needs to change.

## Changes

1. **Read-only role list** — adds BigQuery Data Viewer, BigQuery Job User, Service Account Token Creator (WIF), and `bigquery.jobs.create`, with a `<Note>` explaining why the validation query makes Job User necessary. Mirrors the structure of the Writeback block below it.
2. **WIF Project ID step** — was described as "the project where you created your service account". It is the project Domo runs and bills queries in, which is where `bigquery.jobs.create` is enforced. Granting the role on a project that only stores the data does not satisfy it, which is a common cause of the error persisting after the role is added.
3. **New Troubleshoot section** — the verbatim error text in a fenced block so it is searchable, the fix, the two things to check when the role appears to already be granted, and the grant/create/revoke workaround for customers whose policy disallows holding job-creation rights permanently (noting that data freshness checks stop working).

Also adds Service Account Token Creator to the read-only list: Domo's WIF path impersonates the service account named in the configuration file, so that role is needed for any WIF request, not only writeback.

## Checks

- `yarn remark s/article/000005237.mdx` — **0 errors**, exit 0
- No new warning classes. Adds 2 `list-item-content-indent` warnings, the same type the existing Writeback roles list already produces, because the new read-only list matches its 4-space sub-indent. Happy to switch to 2-space if you would rather be lint-clean than consistent with the adjacent block.
- Italics use `_` per `remarkLintEmphasisMarker`; no `<Frame>` in table cells; headings Title Case and imperative, consistent with the rest of the article.

Internal reference: DOMO-495486
