### PR TITLE
Clarify grants not required to use email Code Engine functions

### DIFF
--- a/s/article/Use-Email-Code-Engine-Functions.mdx
+++ b/s/article/Use-Email-Code-Engine-Functions.mdx
@@ -13,12 +13,7 @@ The package provides several focused email functions—one for each common recip
 
 ## Required Grants
 
-To create and manage Code Engine packages, the following grants must be enabled for your role:
-
-- **Manage Code Engine Packages —** Allows you to perform any action on any Code Engine package in the instance. This grant should be given to admins or anyone who helps manage Code Engine.
-- **Create Code Engine Packages —** Allows you to create a new Code Engine package. This grant should be given to anyone who needs to create and add new function packages to the Code Engine repository in your instance.
-
-The email functions belong to a global package that Domo maintains, so you don't need either grant to use them. Anyone with access to Code Engine and Execute permission on the package can call these functions from a Workflow. Contact your Domo account team to enable Code Engine grants for your instance.
+The email functions belong to a global package that Domo maintains, so you don't need any special grant to use them. Anyone with access to Code Engine and Execute permission on the package can call these functions from a Workflow. Contact your Domo account team to enable Code Engine for your instance.
 
 Learn more about [grants](/s/article/360043438973).
 


### PR DESCRIPTION
## What
Reworks the **Required Grants** section of the *Use Email Code Engine Functions* article so it only covers what's needed to **use** the email functions, not to create/manage Code Engine packages.

## Why
The two package-management grants (**Manage Code Engine Packages**, **Create Code Engine Packages**) are irrelevant to callers of the global, Domo-maintained email functions. Listing them was misleading. The paragraph now stands on its own without referencing those grants.

## Change
- Removed the two-bullet grant list.
- Rewrote the paragraph: "you don't need any special grant to use them."
- Kept the "Learn more about grants" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)